### PR TITLE
fix(store): restore optimistic CRUD + add RBAC gates on admin actions

### DIFF
--- a/src/components/MemberNode.tsx
+++ b/src/components/MemberNode.tsx
@@ -4,6 +4,8 @@ import type { LineageInfo } from '../lib/lineage'
 import type { SecondaryPartner } from './views/treeLayout'
 import LineageBadge from './LineageBadge'
 import { useLang } from '../i18n/useT'
+// `t` flows through useLang() (which also exposes `lang`); used for the
+// deceased badge so the "ז״ל" / "RIP" label flips with the active locale.
 
 // Instagram-story-style tree node: photo-ring above a white card with
 // name + date range. Designed to be readable at the default tree scale
@@ -126,7 +128,7 @@ export default function MemberNode({
   onSecondarySelect,
   dataMemberId,
 }: Props) {
-  const { lang } = useLang()
+  const { lang, t } = useLang()
   const deceased = !!member.death_date
   const birthYear = member.birth_date ? new Date(member.birth_date).getFullYear() : null
   const deathYear = member.death_date ? new Date(member.death_date).getFullYear() : null
@@ -215,7 +217,7 @@ export default function MemberNode({
             {deceased && (
               <div className="absolute bottom-0 inset-x-0 flex justify-center pb-1">
                 <span className="text-[9px] bg-black/60 text-white px-1.5 py-[1px] rounded-full font-bold leading-none">
-                  ז״ל
+                  {t.deceasedBadge}
                 </span>
               </div>
             )}

--- a/src/components/TreeSearchModal.tsx
+++ b/src/components/TreeSearchModal.tsx
@@ -155,8 +155,8 @@ export default function TreeSearchModal({
                             {[
                               m.lineage && m.lineage !== 'israel'
                                 ? m.lineage === 'kohen'
-                                  ? '👑 ' + (lang === 'he' ? 'כהן' : 'Kohen')
-                                  : '🎵 ' + (lang === 'he' ? 'לוי' : 'Levi')
+                                  ? '👑 ' + t.lineageKohen
+                                  : '🎵 ' + t.lineageLevi
                                 : null,
                               m.birth_date
                                 ? new Date(m.birth_date).getFullYear()

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -511,15 +511,15 @@ where email = '${dbAdminStatus.email ?? '<האימייל-שלך>'}';`}
                 <BigStat label={t.membersCount} value={members.length} icon="👨‍👩‍👧" grad="from-[#007AFF] to-[#32ADE6]" />
                 <BigStat label={t.adminTabUsers} value={users.length} icon="👤" grad="from-[#32ADE6] to-[#5AC8FA]" />
                 <BigStat label={t.adminTabRequests} value={pendingCount} icon="🔔" grad="from-[#5AC8FA] to-[#64D2FF]" />
-                <BigStat label="ז״ל" value={deceased} icon="🕯️" grad="from-[#8E8E93] to-[#636366]" />
+                <BigStat label={t.statDeceased} value={deceased} icon="🕯️" grad="from-[#8E8E93] to-[#636366]" />
               </div>
 
               {/* Breakdown card */}
               <div className="glass-strong rounded-3xl p-5 shadow-glass">
                 <h3 className="text-sf-subhead font-bold text-[#1C1C1E] mb-3">📈 {t.adminTabOverview}</h3>
                 <div className="space-y-3">
-                  <ProgressRow label="חיים" count={alive} total={members.length} color="#34C759" />
-                  <ProgressRow label="ז״ל" count={deceased} total={members.length} color="#8E8E93" />
+                  <ProgressRow label={t.statAlive} count={alive} total={members.length} color="#34C759" />
+                  <ProgressRow label={t.statDeceased} count={deceased} total={members.length} color="#8E8E93" />
                 </div>
               </div>
 

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -77,6 +77,10 @@ export const translations = {
     // Member Card
     age: 'גיל',
     deceased: '†',
+    deceasedBadge: 'ז״ל',
+    statAlive: 'חיים',
+    statDeceased: 'ז״ל',
+    genericError: 'שגיאה',
 
     // Member Modal
     about: 'אודות',
@@ -743,6 +747,10 @@ export const translations = {
 
     age: 'Age',
     deceased: '†',
+    deceasedBadge: 'RIP',
+    statAlive: 'Living',
+    statDeceased: 'Deceased',
+    genericError: 'Error',
 
     about: 'About',
     family: 'Family',

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -135,7 +135,7 @@ export default function Auth({ demoMode = false, onDemoEnter }: Props) {
         if (error) throw error
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'שגיאה')
+      setError(err instanceof Error ? err.message : t.genericError)
     } finally {
       setLoading(false)
     }

--- a/src/store/useFamilyStore.ts
+++ b/src/store/useFamilyStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { supabase, isSupabaseConfigured } from '../lib/supabase'
+import { canApproveEditRequests, isAdmin } from '../lib/permissions'
 import type {
   Member, Relationship, EditRequest, ViewMode, Profile,
   AccessRequest, UserRole, FamilyTree, MemberNote,
@@ -185,16 +186,16 @@ export const useFamilyStore = create<FamilyState>((set, get) => ({
     // return the empty / scoped set the user is actually entitled to.
     const me = get().profile
     const current = get().members
-    const isAdmin = me?.role === 'admin'
+    const meIsAdmin = me?.role === 'admin'
     const ownsAny = me ? current.some((m) => m.created_by === me.id) : false
-    if (current.length > 0 && (ownsAny || isAdmin)) {
+    if (current.length > 0 && (ownsAny || meIsAdmin)) {
       // Admins legitimately see members they didn't create (every tree
       // in the system), so absence-of-owned-rows is not a leakage
       // signal for them.  Same early-exit either way.
       set({ isLoading: false })
       return
     }
-    if (current.length > 0 && !ownsAny && !isAdmin && me) {
+    if (current.length > 0 && !ownsAny && !meIsAdmin && me) {
       // Non-admin with no owned rows: this is residual leakage from
       // the pre-RLS era.  Drop and re-fetch so the next render
       // reflects exactly what RLS authorises.
@@ -405,15 +406,38 @@ export const useFamilyStore = create<FamilyState>((set, get) => ({
   approveEditRequest: async (requestId) => {
     const req = get().editRequests.find((r) => r.id === requestId)
     if (!req) return
-    await supabase.from('members').update(req.change_data).eq('id', req.target_member_id)
-    await supabase.from('edit_requests').update({ status: 'approved' }).eq('id', requestId)
-    set((s) => ({ editRequests: s.editRequests.filter((r) => r.id !== requestId) }))
-    await get().fetchMembers()
+    // RBAC gate: app-level check that the caller is permitted to approve.
+    // Supabase RLS is the source of truth, but per AGENTS.md the app
+    // must also gate so a misconfigured RLS doesn't silently expose the
+    // action.
+    if (!canApproveEditRequests(get().profile)) return
+    // Optimistic: drop the request locally + apply the member patch so
+    // the admin sees their approval land immediately, even in demo mode
+    // (no Supabase) or when RLS later rejects the write.
+    set((s) => ({
+      editRequests: s.editRequests.filter((r) => r.id !== requestId),
+      members: s.members.map((m) =>
+        m.id === req.target_member_id
+          ? ({ ...m, ...(req.change_data as Partial<Member>) })
+          : m,
+      ),
+    }))
+    try {
+      const { error: mErr } = await supabase.from('members').update(req.change_data).eq('id', req.target_member_id)
+      if (mErr) reportSupabaseFailure('approveEditRequest:member', mErr)
+      const { error: rErr } = await supabase.from('edit_requests').update({ status: 'approved' }).eq('id', requestId)
+      if (rErr) reportSupabaseFailure('approveEditRequest:request', rErr)
+    } catch (err) { reportSupabaseFailure('approveEditRequest', err) }
   },
 
   rejectEditRequest: async (requestId) => {
-    await supabase.from('edit_requests').update({ status: 'rejected' }).eq('id', requestId)
+    if (!canApproveEditRequests(get().profile)) return
+    // Optimistic drop first; Supabase status update is best-effort.
     set((s) => ({ editRequests: s.editRequests.filter((r) => r.id !== requestId) }))
+    try {
+      const { error } = await supabase.from('edit_requests').update({ status: 'rejected' }).eq('id', requestId)
+      if (error) reportSupabaseFailure('rejectEditRequest', error)
+    } catch (err) { reportSupabaseFailure('rejectEditRequest', err) }
   },
 
   // ── Onboarding + RBAC ────────────────────────────────────────────────
@@ -488,21 +512,31 @@ export const useFamilyStore = create<FamilyState>((set, get) => ({
   },
 
   decideAccessRequest: async (id, decision, grantedRole) => {
+    // App-level admin gate. RLS still authoritative server-side; this
+    // mirrors that policy locally so the action is rejected before any
+    // optimistic state change in demo mode.
+    if (!isAdmin(get().profile)) return
     const req = get().accessRequests.find(r => r.id === id)
-    const patch: Record<string, unknown> = {
-      status: decision,
-      decided_at: new Date().toISOString(),
-    }
-    await supabase.from('access_requests').update(patch).eq('id', id)
-    if (decision === 'approved' && req) {
-      const role = grantedRole ?? req.requested_role
-      await supabase.from('profiles').update({ role }).eq('id', req.requester_id)
-    }
+    const decidedAt = new Date().toISOString()
+    // Optimistic update first so the admin sees the decision land
+    // instantly even when Supabase is offline or RLS-blocked.
     set((s) => ({
       accessRequests: s.accessRequests.map(r =>
-        r.id === id ? { ...r, status: decision, decided_at: patch.decided_at as string } : r,
+        r.id === id ? { ...r, status: decision, decided_at: decidedAt } : r,
       ),
     }))
+    try {
+      const { error: aErr } = await supabase
+        .from('access_requests')
+        .update({ status: decision, decided_at: decidedAt })
+        .eq('id', id)
+      if (aErr) reportSupabaseFailure('decideAccessRequest:request', aErr)
+      if (decision === 'approved' && req) {
+        const role = grantedRole ?? req.requested_role
+        const { error: pErr } = await supabase.from('profiles').update({ role }).eq('id', req.requester_id)
+        if (pErr) reportSupabaseFailure('decideAccessRequest:profile', pErr)
+      }
+    } catch (err) { reportSupabaseFailure('decideAccessRequest', err) }
   },
 
   completeOnboarding: async (patch) => {
@@ -512,14 +546,24 @@ export const useFamilyStore = create<FamilyState>((set, get) => ({
       ...patch,
       onboarded_at: new Date().toISOString(),
     }
-    await supabase.from('profiles').update(finalPatch).eq('id', me.id)
+    // Local first so the dashboard banner disappears immediately even
+    // when Supabase is offline / RLS hasn't propagated.
     set({ profile: { ...me, ...finalPatch } })
+    try {
+      const { error } = await supabase.from('profiles').update(finalPatch).eq('id', me.id)
+      if (error) reportSupabaseFailure('completeOnboarding', error)
+    } catch (err) { reportSupabaseFailure('completeOnboarding', err) }
   },
 
   updateProfileById: async (id, patch) => {
-    await supabase.from('profiles').update(patch).eq('id', id)
+    // Update local mirror first so the UI reflects the change without
+    // waiting for the network round-trip.
     const me = get().profile
     if (me?.id === id) set({ profile: { ...me, ...patch } })
+    try {
+      const { error } = await supabase.from('profiles').update(patch).eq('id', id)
+      if (error) reportSupabaseFailure('updateProfileById', error)
+    } catch (err) { reportSupabaseFailure('updateProfileById', err) }
   },
 
   // ── Tree viewport implementation ──────────────────────────────────


### PR DESCRIPTION
Four store actions were awaiting Supabase before updating local state —
the exact pattern AGENTS.md flags as a previous regression. In demo
mode (and on any RLS reject) the user's action appeared to do nothing
because the local mirror never updated.

Affected actions (all now: RBAC gate → optimistic set() → try/catch
supabase with reportSupabaseFailure on error):

  • approveEditRequest   — also applies the member patch locally so
                           the change appears on the card immediately
  • rejectEditRequest    — also missed the optimistic order
  • decideAccessRequest  — admin gate added (RLS was the only line of
                           defence; AGENTS.md requires app-level too)
  • completeOnboarding   — onboarded_at lands locally before network
  • updateProfileById    — same

approveEditRequest + rejectEditRequest now go through
canApproveEditRequests so a master with that flag can act on them; the
previous code had no app-level check at all.

Also renamed the local `isAdmin` boolean inside fetchMembers to
`meIsAdmin` so it doesn't shadow the imported permission helper.

https://claude.ai/code/session_01LppGwaDmEuFc7T6KggF5PJ