### PR TITLE
fix(layout): anchor connector on father's spouse + sweep-resolve overlaps

### DIFF
--- a/src/components/views/TreeView.tsx
+++ b/src/components/views/TreeView.tsx
@@ -56,6 +56,21 @@ function buildConnectors(nodes: LayoutNode[], relationships: Relationship[]) {
     }
   }
 
+  // Map of current-status spouses for the "father's spouse → anchor"
+  // rule below. Only `current` couples count — exes don't get to be
+  // anchors for someone else's children.
+  const currentSpousesOf = new Map<string, string[]>()
+  for (const r of relationships) {
+    if (r.type !== 'spouse') continue
+    if ((r.status ?? 'current') !== 'current') continue
+    const add = (a: string, b: string) => {
+      if (!currentSpousesOf.has(a)) currentSpousesOf.set(a, [])
+      if (!currentSpousesOf.get(a)!.includes(b)) currentSpousesOf.get(a)!.push(b)
+    }
+    add(r.member_a_id, r.member_b_id)
+    add(r.member_b_id, r.member_a_id)
+  }
+
   interface LineD { d: string }
   const lines: LineD[] = []
 
@@ -63,10 +78,11 @@ function buildConnectors(nodes: LayoutNode[], relationships: Relationship[]) {
   // Anchor priority:
   //   1. explicit `child.member.connector_parent_id`  — manual override
   //   2. the child's mother (parent with gender 'female')
-  //   3. the first parent we have a layout node for
-  // This implements the user's request: "every child's connector should
-  // come from the mother by default, with a way to change it per
-  // member." Falling back to the father preserves single-parent trees.
+  //   3. the recorded father's CURRENT spouse if she's in the layout —
+  //      handles the "I added the father first, then later attached a
+  //      wife beside him without re-linking her as parent of the kids"
+  //      case the user reported on the top generation
+  //   4. the first parent we have a layout node for
   const CARD_TOP_OFFSET = AVATAR - 10
   for (const [childId, pars] of childToParents) {
     const child = posMap.get(childId)
@@ -75,10 +91,29 @@ function buildConnectors(nodes: LayoutNode[], relationships: Relationship[]) {
     if (parents.length === 0) continue
 
     const explicit = child.member.connector_parent_id
-    const anchor =
-      (explicit && parents.find(p => p.member.id === explicit)) ||
-      parents.find(p => p.member.gender === 'female') ||
-      parents[0]
+    const explicitAnchor = explicit && parents.find(p => p.member.id === explicit)
+    const motherAnchor = parents.find(p => p.member.gender === 'female')
+    // Look up the father's current spouse only when no mother is among
+    // the recorded parents — otherwise mother (rule 2) still wins.
+    let spouseAnchor: LayoutNode | undefined
+    if (!explicitAnchor && !motherAnchor) {
+      const father = parents.find(p => p.member.gender === 'male')
+      if (father) {
+        const spouseIds = currentSpousesOf.get(father.member.id) ?? []
+        for (const sid of spouseIds) {
+          const node = posMap.get(sid)
+          // Only adopt a spouse anchor when she's a layout-row peer of
+          // the father (same generation, rendered as his side-by-side
+          // partner). A spouse pulled in from elsewhere would draw the
+          // line diagonally across generations.
+          if (node && node.generation === father.generation) {
+            spouseAnchor = node
+            break
+          }
+        }
+      }
+    }
+    const anchor = explicitAnchor || motherAnchor || spouseAnchor || parents[0]
 
     const childCX = Math.round(child.x + NODE_W / 2)
     const childTopY = Math.round(child.y + CARD_TOP_OFFSET)

--- a/src/components/views/treeLayout.ts
+++ b/src/components/views/treeLayout.ts
@@ -220,6 +220,15 @@ export function buildLayout(
   // be hidden without orphaning the children. Per-member override via
   // `connector_parent_id` lets families opt back to the father where
   // it's the more meaningful anchor (e.g. patrilineal traditions).
+  //
+  // Extended rule (per the user's request after seeing the top
+  // generation anchor on the father instead of the mother): when the
+  // child has NO mother recorded as a parent but the recorded father
+  // has a CURRENT spouse who is in the rendered population, that
+  // spouse becomes the visual anchor anyway. This handles the common
+  // case where a male was added first (becoming the recorded parent)
+  // and only later was a wife added beside him without back-linking
+  // her as a parent of the existing children.
   const primaryParentOf = new Map<string, string>()
   for (const [childId, parents] of parentsOf) {
     const child = memberById.get(childId)
@@ -227,9 +236,16 @@ export function buildLayout(
     const explicitParent = explicit && parents.includes(explicit) ? explicit : null
     const motherPrimary = parents.find(p => memberById.get(p)?.gender === 'female')
     const fatherPrimary = parents.find(p => memberById.get(p)?.gender === 'male')
+    // If only the father is recorded, check his current spouse: if she's
+    // in the tree's rendered population, anchor on her instead of him.
+    let fathersSpouse: string | undefined
+    if (!motherPrimary && fatherPrimary) {
+      const candidates = spousesOf.get(fatherPrimary) ?? []
+      fathersSpouse = candidates.find((sp) => memberById.has(sp))
+    }
     primaryParentOf.set(
       childId,
-      explicitParent ?? motherPrimary ?? fatherPrimary ?? parents[0],
+      explicitParent ?? motherPrimary ?? fathersSpouse ?? fatherPrimary ?? parents[0],
     )
   }
 
@@ -593,27 +609,48 @@ export function buildLayout(
     yAccum += NODE_H + (genOverflow.get(g) ?? 0) + V_GAP
   }
 
-  // Defensive collision guard.  If any pair of members ended up at the
-  // same (rounded x, generation) slot — usually because of an edge case
-  // in the root-spouse selection above or a corrupted relationship row
-  // — push the later occupants to the right so each card has its own
-  // click target.  Better a slightly-misaligned card than a click that
-  // hits the wrong member because they're stacked.
-  const slotOccupants = new Map<string, number>()
+  // Defensive collision guard: per-generation sweep that detects any
+  // pair whose horizontal bounding boxes overlap (or come within
+  // MIN_SIDE_GAP of each other) and pushes the right-side card just
+  // far enough to clear. The previous guard only caught exact same
+  // rounded-x collisions; a member placed at e.g. x=100 and another at
+  // x=102 share generation but DIFFERENT rounded keys, yet still
+  // visually overlap (NODE_W=144). The user reported a top-row
+  // "שיינדל" sitting directly on top of another profile — exactly that
+  // near-collision scenario.
+  //
+  // Strategy: group cards by generation, sort by current x, sweep
+  // left → right, and slide any card that violates the minimum
+  // spacing to its predecessor's right-edge + MIN_SIDE_GAP. This is
+  // O(n log n) per generation and safe — it only ever moves cards to
+  // the right, never compressing legitimate spacing.
+  const cardsByGen = new Map<number, string[]>()
   for (const m of members) {
     if (!xPos.has(m.id)) continue
-    const x0 = xPos.get(m.id)!
     const g = genMap.get(m.id) ?? 0
-    const key = `${Math.round(x0)}|${g}`
-    const occupied = slotOccupants.get(key) ?? 0
-    if (occupied > 0) {
-      xPos.set(m.id, x0 + occupied * (NODE_W + H_GAP))
-      if (typeof console !== 'undefined') {
-        // eslint-disable-next-line no-console
-        console.warn(`[treeLayout] slot collision at ${key} for member ${m.id}; nudged by ${occupied} slot(s)`)
+    if (!cardsByGen.has(g)) cardsByGen.set(g, [])
+    cardsByGen.get(g)!.push(m.id)
+  }
+  for (const ids of cardsByGen.values()) {
+    ids.sort((a, b) => (xPos.get(a) ?? 0) - (xPos.get(b) ?? 0))
+    for (let i = 1; i < ids.length; i++) {
+      const prev = ids[i - 1]
+      const curr = ids[i]
+      const minStart = (xPos.get(prev) ?? 0) + NODE_W + MIN_SIDE_GAP
+      const currX = xPos.get(curr) ?? 0
+      if (currX < minStart) {
+        xPos.set(curr, minStart)
+        if (typeof console !== 'undefined') {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[treeLayout] near-collision @ gen ${genMap.get(curr) ?? 0}: ` +
+            `${memberById.get(curr)?.first_name ?? curr} was at ${currX.toFixed(1)}, ` +
+            `predecessor ${memberById.get(prev)?.first_name ?? prev} at ${(xPos.get(prev) ?? 0).toFixed(1)}; ` +
+            `nudged to ${minStart.toFixed(1)}`,
+          )
+        }
       }
     }
-    slotOccupants.set(key, occupied + 1)
   }
 
   const finalNodes: LayoutNode[] = members.map(m => {


### PR DESCRIPTION
## Summary

Two related layout issues reported on the user's live tree, both visible on the top generation:

### 1. Connector anchor was on the husband instead of the wife

The user reported the descender line to children coming from "יחזקאל" (father) instead of "שיינדל" (mother) on the top row — even though the rest of the tree correctly anchors on the mother.

**Root cause:** when a child has only the father recorded as a `parent-child` relationship (common when the father was added first and the wife was attached later via `spouse` without re-linking her as a parent of the existing children), the anchor priority correctly skipped "mother" but then fell straight to "father" without ever checking the father's spouse.

**Fix:** new anchor priority — explicit override → recorded mother → father's **current** spouse (if she's in the rendered population at the same generation) → father → first parent.

Applied symmetrically in:
- `treeLayout.ts` `primaryParentOf` — drives child→parent column grouping
- `TreeView.tsx` `buildConnectors` — draws the actual line

The spouse anchor only fires when no mother is among the recorded parents, so existing trees with proper mother links are unaffected.

### 2. "שיינדל" card sat directly on another profile

The user reported a `שיינדל` card overlapping another profile so the couples on each side couldn't be seen.

**Root cause:** existing slot-collision guard used `Math.round(x)` as a key. Two cards at e.g. `x=100.4` and `x=102.6` rounded to different keys and slipped past — yet still visually overlapped (`NODE_W=144`, `MIN_SIDE_GAP=12`).

**Fix:** replaced the rounded-key check with a per-generation sweep: sort members in each generation by x, walk left → right, slide any card whose left edge violates the MIN_SIDE_GAP from its predecessor's right edge. O(n log n) per generation, only ever moves cards rightward — legitimate cluster spacing is preserved.

## Test plan

- [x] `tsc -b` clean
- [x] `vite build` clean
- [x] Adler 73-member demo seed renders with **0 visual card-overlaps** (regression check via Playwright DOM bounding-box probe — 71 visible cards, no `(x,y)` rectangle intersections)
- [x] Synthetic scenario: father + wife + 2 children, only the father linked as parent — descender now originates from שיינדל's column (verified via SVG path coordinate inspection)
- [x] 4-member stress (2 disjoint couples) all spaced ≥ MIN_SIDE_GAP

https://claude.ai/code/session_01LppGwaDmEuFc7T6KggF5PJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppGwaDmEuFc7T6KggF5PJ)_