### PR TITLE
fix(member-add): inherit tree_id from related member, not main pool

### DIFF
--- a/src/components/RelationshipManager.tsx
+++ b/src/components/RelationshipManager.tsx
@@ -143,6 +143,14 @@ export default function RelationshipManager({ open, onClose, member }: Props) {
         last_name: newLast.trim() || member.last_name,
         gender: (newGender || undefined) as Gender | undefined,
         created_by: profile?.id ?? 'demo',
+        // Inherit the same tree as the existing related member.
+        // Without this, the new parent/spouse/child is created with
+        // tree_id=null and ends up in the main tree pool — invisible
+        // from any sub-tree view the user is currently in. Live bug:
+        // user created "ילד" in "עץ הניסיון", added "אבא" as a parent
+        // via this modal, and "אבא" landed alone in the main Adler
+        // tree instead of beside the child.
+        tree_id: member.tree_id ?? undefined,
       })
       if (created) {
         const pt = parentTypeDraft !== 'bio' ? parentTypeDraft : undefined

--- a/src/components/ai/AIScanModal.tsx
+++ b/src/components/ai/AIScanModal.tsx
@@ -54,7 +54,7 @@ export default function AIScanModal({
 }) {
   const { t, lang } = useLang()
   const rtl = isRTL(lang)
-  const { addMember, addRelationship, members, profile } = useFamilyStore()
+  const { addMember, addRelationship, members, profile, activeTreeId } = useFamilyStore()
   const fileRef = useRef<HTMLInputElement>(null)
 
   const [phase, setPhase] = useState<Phase>('pick')
@@ -137,6 +137,14 @@ export default function AIScanModal({
     try {
       const creatorId = profile?.id ?? 'ai-scan'
       for (const c of picked) {
+        // Anchor relative's tree wins over activeTreeId so AI-imported
+        // members land in the same tree as the relative they're being
+        // placed next to (not the tree currently being viewed, which
+        // could differ if the user switched views mid-flow).
+        const anchor = c.placement.relativeId
+          ? members.find((m) => m.id === c.placement.relativeId)
+          : null
+        const treeIdForNew = anchor?.tree_id ?? activeTreeId ?? undefined
         const member: Omit<Member, 'id'> = {
           first_name: c.first_name,
           last_name: c.last_name ?? '',
@@ -144,6 +152,7 @@ export default function AIScanModal({
           birth_date: c.birth_year ? `${c.birth_year}-01-01` : undefined,
           bio: c.notes,
           created_by: creatorId,
+          tree_id: treeIdForNew,
         }
         const created = await addMember(member)
         // Wire the placement chosen during the chat — sibling means


### PR DESCRIPTION
## Summary

User reproduced a critical bug: created a child "ילד" inside a sub-tree ("עץ הניסיון"), then added a parent "אבא" via the RelationshipManager. The parent landed alone in the MAIN Adler tree instead of inside "עץ הניסיון".

**Root cause:** `addMember` was called without a `tree_id`, so the new row defaulted to `null` — which the tree filter treats as the main pool.

## Fix

Two call sites had the same bug:

- **`RelationshipManager.tsx` `createAndLink`** — pass `tree_id: member.tree_id` so the new parent/spouse/child inherits the anchor member's tree. Using the anchor's tree (not `activeTreeId`) survives a mid-flow tree switch.
- **`AIScanModal.tsx` `confirmAdd`** — same logic. When the candidate has a `placement.relativeId`, inherit from that anchor; otherwise fall back to `activeTreeId`.

`AddMemberModal` already passed `tree_id: activeTreeId` correctly. `OnboardingWizard` + `BuildFromTextModal` already handle it. So only the two call sites above were broken.

## Test plan

- [x] `tsc -b` clean
- [x] `vite build` clean
- [x] Repro the user's exact scenario via Playwright: create child in sub-tree, call `addMember` + `addRelationship` the way RelationshipManager does → new parent's `tree_id` matches the child's (`test-tree-1`), not `null`
- [x] Couple-adjacency regression (3 scenarios from PR #19) still passes — top-row order is `[h1, w1, h2, w2]` in all variants

https://claude.ai/code/session_01LppGwaDmEuFc7T6KggF5PJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppGwaDmEuFc7T6KggF5PJ)_