### PR TITLE
feat(dashboard): expose /lab tile for admins

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -747,6 +747,24 @@ export default function Dashboard({ demoMode }: Props) {
                 onClick={() => navigate('/admin')}
               />
             )}
+            {/* Experimental lab tile — gated to admins so it stays out
+                of the way for normal users while the editor's UX is
+                still being prototyped. The /lab route itself is
+                public (no auth needed); this is just the entry point. */}
+            {isAdmin(profile) && (
+              <AppTile
+                index={8}
+                icon="🧪"
+                label={lang === 'he' ? 'מעבדת קווים' : 'Lab'}
+                gradient="from-[#34C759] to-[#06D6A0]"
+                onClick={() => navigate('/lab')}
+                tooltip={
+                  lang === 'he'
+                    ? 'עורך קווי-עץ ניסיוני — נתונים מבודדים'
+                    : 'Experimental tree-edge editor — isolated data'
+                }
+              />
+            )}
           </div>
         </motion.section>
 


### PR DESCRIPTION
## Why

User couldn't find the `/lab` playground from PR #21 because it had no UI entry point — only the direct URL. PWA service-worker also seems to be caching the pre-#21 bundle on their device, so even the URL wasn't working.

## What

Adds a small green tile to the dashboard's admin app-grid that navigates to `/lab`. Gated to admins so it stays out of the way for normal users while the editor is still experimental.

Side effect (intended): this push bumps the build version, which makes the PWA "new version available" modal pop on the user's device and replaces the cached bundle.

## Test plan

- [x] `tsc -b` clean
- [x] `vite build` clean

https://claude.ai/code/session_01LppGwaDmEuFc7T6KggF5PJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppGwaDmEuFc7T6KggF5PJ)_