### PR TITLE
feat(lab): tap-vs-longpress + per-edge edit mode with delete

### DIFF
--- a/src/pages/Lab.tsx
+++ b/src/pages/Lab.tsx
@@ -1,42 +1,60 @@
 import { useState, useRef, useMemo, useCallback, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { motion } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 import { useLang, isRTL } from '../i18n/useT'
 import MemberNode from '../components/MemberNode'
 import type { Member } from '../types'
 
-// Experimental tree-editor playground.
-// Lives at /lab — completely isolated from the main app's Zustand
-// store so the user can break things freely without touching the
-// real family data.
+// Experimental tree-editor playground at /lab.
 //
-// Architecture (mirrors the production /tree page so the playground
-// FEELS like the real app, not a placeholder):
-//   • Pan + pinch-zoom inherited verbatim from TreeView — same
-//     transform-on-wrapper approach, same wheel / mouse / touch math.
-//     Local viewport state, not the store's, so /lab doesn't fight
-//     /tree over the camera.
-//   • Member cards are the real MemberNode component (gender ring,
-//     proper avatar, name, RIP/Kohen badges). Identical look-and-feel
-//     to /tree.
-//   • Connectors are the NEW behaviour being prototyped: smooth
-//     Bezier curves with grabbable handles at the child end. Drag
-//     within SNAP_RADIUS of a member to re-bind; release in empty
-//     space to leave the edge dangling (rendered green).
+// Interaction model (the third revision — the user is iterating on
+// the UX in tight cycles):
 //
-// Pointer-capture is used for handle drags so the pan handler on the
-// outer wrapper doesn't fight the handle-drag — the handle "owns"
-// the pointer once it's grabbed.
+//   Profile card
+//     • Single tap            → open the member's profile modal.
+//     • Long-press (500ms)    → spawn a new dangling edge from
+//                                that person. A green dot + green
+//                                bezier stub appears below them.
+//
+//   Line (connector)
+//     • Single tap            → nothing (lines look clean).
+//     • Long-press (500ms)    → enter EDIT mode for that edge:
+//                                handles appear at BOTH endpoints
+//                                (source + target), a delete X
+//                                floats by the midpoint, and the
+//                                stroke gets a subtle highlight.
+//
+//   Handle (visible blue/green dot)
+//     • Drag                  → re-target that endpoint. Within
+//                                SNAP_RADIUS of a member's anchor
+//                                it locks onto them; released over
+//                                empty space → edge dangles green.
+//
+//   Empty canvas
+//     • Drag                  → pan the camera (mouse + touch).
+//     • Wheel / pinch         → zoom (cursor-anchored).
+//     • Tap                   → exit any active EDIT mode.
+//
+// All long-press timers cancel if the pointer moves more than
+// MOVE_TOLERANCE pixels — keeps pan gestures from accidentally
+// triggering edits.
 
 // ── Constants ──────────────────────────────────────────────────────
-const SNAP_RADIUS = 90        // world-units (pre-zoom) for snap detection
-const NODE_W = 144            // matches MemberNode card width @ default size
-const NODE_H = 138            // matches MemberNode card height @ default size
-const AVATAR = 72             // MemberNode default avatar diameter
-const TOP_ANCHOR_OFFSET = 12  // distance from card top down to where parent connector lands
-const BOTTOM_ANCHOR_OFFSET = NODE_H - 20
+const SNAP_RADIUS     = 90    // world-units; pull-into-anchor distance
+const NODE_W          = 144   // MemberNode card width @ default size
+const NODE_H          = 138
+const AVATAR          = 72
+// Anchor offsets sit a few px OUTSIDE the card so handles and the
+// line endpoints remain visible — the previous values placed the
+// source handle inside the card body where it was masked by the
+// MemberNode chrome.
+const TOP_ANCHOR_OFFSET    = -4         // just above the card (above avatar)
+const BOTTOM_ANCHOR_OFFSET = NODE_H + 4 // just below the card
+const LONG_PRESS_MS   = 500
+const MOVE_TOLERANCE  = 10    // px in CLIENT coords — same threshold
+                              // for cancelling profile + line long-press
 
-// ── Seed: small family to play with ──────────────────────────────
+// ── Seed family ────────────────────────────────────────────────────
 function makeMember(id: string, first: string, gender: 'male' | 'female'): Member {
   return { id, first_name: first, last_name: 'ניסוי', gender, created_by: 'lab' }
 }
@@ -49,9 +67,6 @@ const SEED_MEMBERS: Member[] = [
   makeMember('c3', 'ילד 3', 'male'),
 ]
 
-// World-coordinate positions (pre-zoom). The auto-fit effect picks
-// a scale that makes the whole family visible on mount, so these
-// stay in a fixed "design canvas" regardless of viewport size.
 const SEED_POSITIONS: Record<string, { x: number; y: number }> = {
   mom: { x: 180, y:   0 },
   dad: { x: 360, y:   0 },
@@ -62,7 +77,7 @@ const SEED_POSITIONS: Record<string, { x: number; y: number }> = {
 
 interface LabEdge {
   id: string
-  /** Parent member id — the "source" end of the connector. Fixed. */
+  /** Parent member id (source). */
   source: string
   /** Child member id, or null when the edge is dangling. */
   target: string | null
@@ -70,12 +85,12 @@ interface LabEdge {
 
 const SEED_EDGES: LabEdge[] = [
   { id: 'e1', source: 'mom', target: 'c1' },
-  { id: 'e2', source: 'mom', target: null }, // demonstrates the dangling/green state
+  { id: 'e2', source: 'mom', target: null }, // demonstrates dangling/green state
 ]
 
-// Bezier path with control points at the vertical midpoint. From the
-// user's PoC — eases the line out of the parent and into the child
-// without sharp elbows.
+// Which endpoint of an edge is being dragged.
+type DragWhich = 'source' | 'target'
+
 function bezierPath(sx: number, sy: number, ex: number, ey: number): string {
   const dy = Math.abs(ey - sy)
   const cy1 = sy + dy * 0.5
@@ -83,8 +98,6 @@ function bezierPath(sx: number, sy: number, ex: number, ey: number): string {
   return `M ${sx} ${sy} C ${sx} ${cy1}, ${ex} ${cy2}, ${ex} ${ey}`
 }
 
-// Card anchors. Cards are positioned with their top-left at (x,y), so
-// the bottom-centre / top-centre attachments are simple offsets.
 function bottomAnchor(p: { x: number; y: number }) {
   return { x: p.x + NODE_W / 2, y: p.y + BOTTOM_ANCHOR_OFFSET }
 }
@@ -103,21 +116,46 @@ export default function Lab() {
   const [edges, setEdges] = useState<LabEdge[]>(SEED_EDGES)
   const memberById = useMemo(() => new Map(members.map((m) => [m.id, m])), [members])
 
+  // ── UI state ─────────────────────────────────────────────────────
+  /** Which edge is in EDIT mode (handles + delete visible). */
+  const [editingEdge, setEditingEdge] = useState<string | null>(null)
+  /** Which member's profile modal is open (null = closed). */
+  const [profileMember, setProfileMember] = useState<Member | null>(null)
+  /** Active handle drag — { edgeId, which: 'source' | 'target' }. */
+  const [dragging, setDragging] = useState<{ edgeId: string; which: DragWhich } | null>(null)
+  const [hoverTarget, setHoverTarget] = useState<string | null>(null)
+  const [worldPointer, setWorldPointer] = useState<{ x: number; y: number }>({ x: 0, y: 0 })
+
   // ── Viewport (pan + zoom) ────────────────────────────────────────
-  // Same model as TreeView: a single transform on the canvas inner
-  // wrapper. Local state so /lab is independent from /tree.
   const [scale, setScale] = useState(1)
   const [tx, setTx] = useState(0)
   const [ty, setTy] = useState(0)
   const [initialised, setInitialised] = useState(false)
   const wrapRef = useRef<HTMLDivElement>(null)
-  const dragState = useRef<{ startX: number; startY: number; tx0: number; ty0: number } | null>(null)
+  const panState = useRef<{ startX: number; startY: number; tx0: number; ty0: number } | null>(null)
   type TouchMode =
     | { mode: 'pan'; startX: number; startY: number; tx0: number; ty0: number }
     | { mode: 'pinch'; initialDist: number; initialScale: number; cx: number; cy: number; tx0: number; ty0: number }
   const touchState = useRef<TouchMode | null>(null)
 
-  // Canvas world-bounds — computed from the seed positions, padded.
+  // Tracks whether the current pan gesture has actually moved beyond
+  // a few pixels. If it hasn't, an empty-canvas tap is a "tap to
+  // exit edit mode" gesture, not a pan.
+  const panMoved = useRef(false)
+
+  // ── Long-press timers ────────────────────────────────────────────
+  // One for profiles ("spawn new edge"), one for lines ("enter edit
+  // mode"). Each stores { startX, startY, timerId, fired }. fired
+  // flips to true when the timeout actually runs, so the matching
+  // pointerup can suppress its short-tap action.
+  const profilePress = useRef<{
+    memberId: string; startX: number; startY: number; timerId: number; fired: boolean
+  } | null>(null)
+  const linePress = useRef<{
+    edgeId: string; startX: number; startY: number; timerId: number; fired: boolean
+  } | null>(null)
+
+  // ── Canvas dimensions / auto-fit ─────────────────────────────────
   const PAD = 80
   const maxX = Math.max(...Object.values(positions).map((p) => p.x + NODE_W)) + PAD
   const maxY = Math.max(...Object.values(positions).map((p) => p.y + NODE_H)) + PAD
@@ -126,8 +164,6 @@ export default function Lab() {
   const canvasH = maxY + PAD
   const offsetX = -minX
 
-  // Auto-fit on mount — scale so the whole design canvas is visible,
-  // then centre it. After this fires once, the user owns the camera.
   useEffect(() => {
     if (initialised) return
     const el = wrapRef.current
@@ -143,8 +179,41 @@ export default function Lab() {
     setInitialised(true)
   }, [initialised, canvasW, canvasH])
 
-  // Wheel zoom — anchored on the cursor so zooming in keeps the
-  // pointed-at point stationary on screen.
+  // ── Coordinate helper ────────────────────────────────────────────
+  const clientToWorld = useCallback((clientX: number, clientY: number) => {
+    const rect = wrapRef.current?.getBoundingClientRect()
+    if (!rect) return { x: 0, y: 0 }
+    // Subtract offsetX so positions match the seed coord system
+    // (positions are stored pre-offset).
+    return {
+      x: (clientX - rect.left - tx) / scale - offsetX,
+      y: (clientY - rect.top - ty) / scale,
+    }
+  }, [tx, ty, scale, offsetX])
+
+  // ── Snap target detection ────────────────────────────────────────
+  // The snap anchor depends on WHICH endpoint is being dragged:
+  //   • Dragging the source (parent end) → snap to a member's BOTTOM
+  //     anchor (where the parent line originates).
+  //   • Dragging the target (child end)  → snap to a member's TOP
+  //     anchor (where the child line lands).
+  const findSnapTarget = useCallback((wx: number, wy: number, which: DragWhich): string | null => {
+    let best: string | null = null
+    let bestDist = SNAP_RADIUS
+    for (const m of members) {
+      const pos = positions[m.id]
+      if (!pos) continue
+      const a = which === 'source' ? bottomAnchor(pos) : topAnchor(pos)
+      const d = Math.hypot(wx - a.x, wy - a.y)
+      if (d < bestDist) {
+        bestDist = d
+        best = m.id
+      }
+    }
+    return best
+  }, [members, positions])
+
+  // ── Pan / zoom handlers (outer wrapper) ──────────────────────────
   const onWheel = (e: React.WheelEvent) => {
     e.preventDefault()
     const delta = -e.deltaY * 0.0015
@@ -159,29 +228,38 @@ export default function Lab() {
     setScale(newScale)
   }
 
-  // Mouse pan — only kicks in when the user clicks empty canvas;
-  // handle-drag stops propagation so this never fires for handles.
   const onMouseDown = (e: React.MouseEvent) => {
-    if ((e.target as HTMLElement).closest('[data-lab-handle]')) return
-    dragState.current = { startX: e.clientX, startY: e.clientY, tx0: tx, ty0: ty }
+    // Skip if the target is interactive (profile, line, handle).
+    if ((e.target as HTMLElement).closest('[data-lab-interactive]')) return
+    panState.current = { startX: e.clientX, startY: e.clientY, tx0: tx, ty0: ty }
+    panMoved.current = false
   }
   const onMouseMove = (e: React.MouseEvent) => {
-    if (!dragState.current) return
-    setTx(dragState.current.tx0 + (e.clientX - dragState.current.startX))
-    setTy(dragState.current.ty0 + (e.clientY - dragState.current.startY))
+    if (!panState.current) return
+    const dx = e.clientX - panState.current.startX
+    const dy = e.clientY - panState.current.startY
+    if (Math.hypot(dx, dy) > 3) panMoved.current = true
+    setTx(panState.current.tx0 + dx)
+    setTy(panState.current.ty0 + dy)
   }
-  const onMouseUp = () => { dragState.current = null }
+  const onMouseUp = (e: React.MouseEvent) => {
+    if (panState.current && !panMoved.current) {
+      // Empty-canvas tap → exit edit mode if any.
+      if (!(e.target as HTMLElement).closest('[data-lab-interactive]')) {
+        setEditingEdge(null)
+      }
+    }
+    panState.current = null
+  }
 
-  // Touch pan + pinch-zoom — same math as TreeView. The handle's
-  // pointer-capture takes precedence (handle uses pointer events,
-  // these are touch events).
   const onTouchStart = (e: React.TouchEvent) => {
-    if ((e.target as HTMLElement).closest('[data-lab-handle]')) return
+    if ((e.target as HTMLElement).closest('[data-lab-interactive]')) return
     const rect = wrapRef.current?.getBoundingClientRect()
     if (!rect) return
     if (e.touches.length === 1) {
       const t = e.touches[0]
       touchState.current = { mode: 'pan', startX: t.clientX, startY: t.clientY, tx0: tx, ty0: ty }
+      panMoved.current = false
     } else if (e.touches.length >= 2) {
       const [a, b] = [e.touches[0], e.touches[1]]
       const dist = Math.hypot(b.clientX - a.clientX, b.clientY - a.clientY) || 1
@@ -195,8 +273,11 @@ export default function Lab() {
     if (!st) return
     if (st.mode === 'pan' && e.touches.length === 1) {
       const t = e.touches[0]
-      setTx(st.tx0 + (t.clientX - st.startX))
-      setTy(st.ty0 + (t.clientY - st.startY))
+      const dx = t.clientX - st.startX
+      const dy = t.clientY - st.startY
+      if (Math.hypot(dx, dy) > 3) panMoved.current = true
+      setTx(st.tx0 + dx)
+      setTy(st.ty0 + dy)
     } else if (st.mode === 'pinch' && e.touches.length >= 2) {
       const [a, b] = [e.touches[0], e.touches[1]]
       const dist = Math.hypot(b.clientX - a.clientX, b.clientY - a.clientY) || 1
@@ -210,6 +291,15 @@ export default function Lab() {
     }
   }
   const onTouchEnd = (e: React.TouchEvent) => {
+    const wasTap =
+      touchState.current?.mode === 'pan' &&
+      !panMoved.current &&
+      e.touches.length === 0
+    if (wasTap) {
+      if (!(e.target as HTMLElement).closest('[data-lab-interactive]')) {
+        setEditingEdge(null)
+      }
+    }
     if (e.touches.length === 0) {
       touchState.current = null
     } else if (e.touches.length === 1) {
@@ -218,9 +308,6 @@ export default function Lab() {
     }
   }
 
-  // Buttons that the user can tap to zoom in/out (handy on phones
-  // where pinch is annoying when the gesture starts close to the
-  // edge).
   const zoomBy = (factor: number) => {
     const newScale = Math.max(0.1, Math.min(6, scale * factor))
     const w = wrapRef.current?.clientWidth ?? 0
@@ -233,84 +320,131 @@ export default function Lab() {
     setScale(newScale)
   }
 
-  // ── Handle-drag (the "edit edge" interaction) ────────────────────
-  // The handle uses Pointer Events with setPointerCapture so all
-  // subsequent move/up events route to the handle even when the
-  // pointer leaves its hit area. The pan handlers above check for
-  // [data-lab-handle] and bail out, so the two systems don't fight.
-  const [draggingEdge, setDraggingEdge] = useState<string | null>(null)
-  const [hoverTarget, setHoverTarget] = useState<string | null>(null)
-  // Pointer position in WORLD coords during a handle drag.
-  const [worldPointer, setWorldPointer] = useState<{ x: number; y: number }>({ x: 0, y: 0 })
-
-  const clientToWorld = useCallback((clientX: number, clientY: number) => {
-    const rect = wrapRef.current?.getBoundingClientRect()
-    if (!rect) return { x: 0, y: 0 }
-    return { x: (clientX - rect.left - tx) / scale, y: (clientY - rect.top - ty) / scale }
-  }, [tx, ty, scale])
-
-  const findSnapTarget = useCallback((wx: number, wy: number): string | null => {
-    let best: string | null = null
-    let bestDist = SNAP_RADIUS
-    for (const m of members) {
-      const pos = positions[m.id]
-      if (!pos) continue
-      const a = topAnchor(pos)
-      const d = Math.hypot(wx - a.x, wy - a.y)
-      if (d < bestDist) {
-        bestDist = d
-        best = m.id
-      }
+  // ── Profile long-press / tap ─────────────────────────────────────
+  const onProfilePointerDown = (memberId: string, e: React.PointerEvent) => {
+    // Don't preventDefault — we want a normal touch-flow. The wrapper
+    // div carries data-lab-interactive so the outer pan handler
+    // bails out.
+    const startX = e.clientX
+    const startY = e.clientY
+    const timerId = window.setTimeout(() => {
+      // Long-press fired: spawn a new dangling edge from this person.
+      profilePress.current && (profilePress.current.fired = true)
+      const newId = `e-${Date.now().toString(36)}`
+      setEdges((prev) => [...prev, { id: newId, source: memberId, target: null }])
+      // Optional haptic on supporting browsers.
+      try { (navigator as { vibrate?: (n: number) => void }).vibrate?.(15) } catch { /* ignore */ }
+    }, LONG_PRESS_MS)
+    profilePress.current = { memberId, startX, startY, timerId, fired: false }
+  }
+  const onProfilePointerMove = (e: React.PointerEvent) => {
+    const lp = profilePress.current
+    if (!lp) return
+    if (Math.hypot(e.clientX - lp.startX, e.clientY - lp.startY) > MOVE_TOLERANCE) {
+      clearTimeout(lp.timerId)
+      profilePress.current = null
     }
-    return best
-  }, [members, positions])
+  }
+  const onProfilePointerUp = (memberId: string) => {
+    const lp = profilePress.current
+    if (!lp) return
+    clearTimeout(lp.timerId)
+    if (!lp.fired) {
+      // Short tap → open the profile.
+      const m = memberById.get(memberId)
+      if (m) setProfileMember(m)
+    }
+    profilePress.current = null
+  }
 
-  const onHandlePointerDown = useCallback((edgeId: string, e: React.PointerEvent<SVGCircleElement>) => {
+  // ── Line long-press → enter edit mode ────────────────────────────
+  const onLinePointerDown = (edgeId: string, e: React.PointerEvent<SVGPathElement>) => {
+    // Capture so move/up events still route here even if the user
+    // drags off the (thin) line.
+    try { e.currentTarget.setPointerCapture(e.pointerId) } catch { /* ignore */ }
+    const startX = e.clientX
+    const startY = e.clientY
+    const timerId = window.setTimeout(() => {
+      linePress.current && (linePress.current.fired = true)
+      setEditingEdge(edgeId)
+      try { (navigator as { vibrate?: (n: number) => void }).vibrate?.(15) } catch { /* ignore */ }
+    }, LONG_PRESS_MS)
+    linePress.current = { edgeId, startX, startY, timerId, fired: false }
+  }
+  const onLinePointerMove = (e: React.PointerEvent<SVGPathElement>) => {
+    const lp = linePress.current
+    if (!lp) return
+    if (Math.hypot(e.clientX - lp.startX, e.clientY - lp.startY) > MOVE_TOLERANCE) {
+      clearTimeout(lp.timerId)
+      linePress.current = null
+    }
+  }
+  const onLinePointerUp = (e: React.PointerEvent<SVGPathElement>) => {
+    const lp = linePress.current
+    if (!lp) return
+    clearTimeout(lp.timerId)
+    try { e.currentTarget.releasePointerCapture(e.pointerId) } catch { /* ignore */ }
+    linePress.current = null
+  }
+
+  // ── Handle drag (the actual edit gesture) ────────────────────────
+  const onHandlePointerDown = useCallback((edgeId: string, which: DragWhich, e: React.PointerEvent<SVGCircleElement>) => {
     e.stopPropagation()
     e.preventDefault()
-    e.currentTarget.setPointerCapture(e.pointerId)
-    setDraggingEdge(edgeId)
-    // Detach immediately so the line follows the cursor and turns green.
-    setEdges((prev) => prev.map((edge) => (edge.id === edgeId ? { ...edge, target: null } : edge)))
+    try { e.currentTarget.setPointerCapture(e.pointerId) } catch { /* ignore */ }
+    setDragging({ edgeId, which })
+    // Detach the dragged endpoint so the line follows the cursor.
+    setEdges((prev) => prev.map((edge) => {
+      if (edge.id !== edgeId) return edge
+      if (which === 'target') return { ...edge, target: null }
+      // For source drag, we DON'T null it — visual continuity
+      // requires the line to keep starting somewhere. We just track
+      // the drag and snap to a new source on release.
+      return edge
+    }))
     const w = clientToWorld(e.clientX, e.clientY)
     setWorldPointer(w)
-    setHoverTarget(findSnapTarget(w.x, w.y))
+    setHoverTarget(findSnapTarget(w.x, w.y, which))
   }, [clientToWorld, findSnapTarget])
 
   const onHandlePointerMove = useCallback((e: React.PointerEvent<SVGCircleElement>) => {
-    if (!draggingEdge) return
+    if (!dragging) return
     const w = clientToWorld(e.clientX, e.clientY)
     setWorldPointer(w)
-    setHoverTarget(findSnapTarget(w.x, w.y))
-  }, [draggingEdge, clientToWorld, findSnapTarget])
+    setHoverTarget(findSnapTarget(w.x, w.y, dragging.which))
+  }, [dragging, clientToWorld, findSnapTarget])
 
   const onHandlePointerUp = useCallback((e: React.PointerEvent<SVGCircleElement>) => {
-    if (!draggingEdge) return
-    try { e.currentTarget.releasePointerCapture(e.pointerId) } catch { /* already released */ }
+    if (!dragging) return
+    try { e.currentTarget.releasePointerCapture(e.pointerId) } catch { /* ignore */ }
     const target = hoverTarget
-    setEdges((prev) =>
-      prev.map((edge) => {
-        if (edge.id !== draggingEdge) return edge
+    setEdges((prev) => prev.map((edge) => {
+      if (edge.id !== dragging.edgeId) return edge
+      if (dragging.which === 'target') {
         if (target) {
           // eslint-disable-next-line no-console
-          console.log(`[lab] edge ${edge.id}: ${edge.source} → ${target}`)
+          console.log(`[lab] edge ${edge.id} target: ${edge.source} → ${target}`)
           return { ...edge, target }
         }
+        return edge // stays dangling
+      }
+      // Source-end drag: only commit if it landed on a real member,
+      // otherwise revert to the original parent.
+      if (target) {
         // eslint-disable-next-line no-console
-        console.log(`[lab] edge ${edge.id} released over empty space (dangling)`)
-        return edge
-      }),
-    )
-    setDraggingEdge(null)
+        console.log(`[lab] edge ${edge.id} source: ${target} → ${edge.target ?? 'dangling'}`)
+        return { ...edge, source: target }
+      }
+      return edge
+    }))
+    setDragging(null)
     setHoverTarget(null)
-  }, [draggingEdge, hoverTarget])
+  }, [dragging, hoverTarget])
 
-  // Double-click a card to spawn a fresh dangling edge from it. Lets
-  // the user actually grow the structure beyond the seed.
-  const spawnDanglingEdge = useCallback((sourceId: string) => {
-    const newId = `e-${Date.now().toString(36)}`
-    setEdges((prev) => [...prev, { id: newId, source: sourceId, target: null }])
-  }, [])
+  const deleteEdge = (edgeId: string) => {
+    setEdges((prev) => prev.filter((e) => e.id !== edgeId))
+    setEditingEdge(null)
+  }
 
   // ── Render ───────────────────────────────────────────────────────
   return (
@@ -339,8 +473,6 @@ export default function Lab() {
           'linear-gradient(135deg, #F4F7FF 0%, #FBF7FF 55%, #FFF5FA 100%)',
       }}
     >
-      {/* Subtle dot grid behind the canvas — matches TreeView's
-          background pattern so /lab feels native to the app. */}
       <div
         className="absolute inset-0 opacity-35 pointer-events-none"
         style={{
@@ -349,40 +481,37 @@ export default function Lab() {
         }}
       />
 
-      {/* Header strip — sits ABOVE the transformed canvas so it stays
-          fixed during pan/zoom. */}
+      {/* Header (above the transform — fixed-size HUD). */}
       <div className="absolute top-0 inset-x-0 z-20 px-4 py-3 flex items-center gap-2 pointer-events-none">
         <button
+          data-lab-interactive
           onClick={() => navigate('/home')}
           className="pointer-events-auto bg-white/95 backdrop-blur rounded-full px-3 py-1.5 text-[13px] font-semibold text-[#1C1C1E] shadow-sm border border-white/60 hover:bg-white transition"
         >
           {rtl ? '← חזרה' : 'Back →'}
         </button>
-        <div className="pointer-events-none flex-1 text-center text-[14px] font-bold text-[#1C1C1E]">
+        <div className="flex-1 text-center text-[14px] font-bold text-[#1C1C1E]">
           {rtl ? '🧪 מעבדת קווים' : 'Lab — Tree edges'}
         </div>
-        <div className="pointer-events-auto flex gap-1">
+        <div className="pointer-events-auto flex gap-1" data-lab-interactive>
           <button
             onClick={() => zoomBy(0.8)}
             className="bg-white/95 backdrop-blur rounded-full w-8 h-8 font-semibold text-[18px] text-[#1C1C1E] shadow-sm border border-white/60 hover:bg-white transition"
-            aria-label="zoom out"
           >−</button>
           <button
             onClick={() => zoomBy(1.25)}
             className="bg-white/95 backdrop-blur rounded-full w-8 h-8 font-semibold text-[18px] text-[#1C1C1E] shadow-sm border border-white/60 hover:bg-white transition"
-            aria-label="zoom in"
           >+</button>
         </div>
       </div>
 
-      {/* Hint strip — only on desktop where we have room. */}
-      <div className="absolute top-14 inset-x-0 z-10 text-center text-[11px] text-[#8E8E93] pointer-events-none hidden md:block">
+      <div className="absolute top-14 inset-x-0 z-10 text-center text-[11px] text-[#8E8E93] pointer-events-none hidden md:block px-4">
         {rtl
-          ? 'גרירה: הזזת תצוגה • גלגלת/צביטה: זום • גרור עיגול בקצה הקו: שינוי יעד • הקשה כפולה על אדם: יצירת קו חדש'
-          : 'Drag: pan • Wheel/pinch: zoom • Drag the line tip: re-target • Double-tap a member: new edge'}
+          ? 'גרירה: הזזה • גלגלת/צביטה: זום • הקשה על פרופיל: פתיחה • לחיצה ארוכה על פרופיל: יצירת קו • לחיצה ארוכה על קו: עריכה'
+          : 'Drag: pan • Wheel/pinch: zoom • Tap profile: open • Hold profile: new edge • Hold line: edit'}
       </div>
 
-      {/* The transformed world — single source of truth for pan/zoom. */}
+      {/* World — transformed wrapper for pan/zoom. */}
       <div
         className="absolute top-0 left-0 origin-top-left"
         style={{
@@ -392,11 +521,9 @@ export default function Lab() {
           transformOrigin: '0 0',
         }}
       >
-        {/* SVG layer for the connectors. Sized to the canvas world so
-            the lines align pixel-perfect with the cards. */}
         <svg
-          className="absolute pointer-events-none"
-          style={{ left: 0, top: 0, overflow: 'visible' }}
+          className="absolute"
+          style={{ left: 0, top: 0, overflow: 'visible', pointerEvents: 'none' }}
           width={canvasW}
           height={canvasH}
         >
@@ -413,21 +540,34 @@ export default function Lab() {
               </feMerge>
             </filter>
           </defs>
+
           {edges.map((edge) => {
             const sourcePos = positions[edge.source]
             if (!sourcePos) return null
-            const isDragging = draggingEdge === edge.id
-            // Translate to canvas-internal coords (offsetX shifts so
-            // negative seed-x values don't render off-canvas).
-            const start = bottomAnchor({ x: sourcePos.x + offsetX, y: sourcePos.y })
+            const inEdit = editingEdge === edge.id
+            const isDraggingTarget = dragging?.edgeId === edge.id && dragging?.which === 'target'
+            const isDraggingSource = dragging?.edgeId === edge.id && dragging?.which === 'source'
+
+            // Compute the two endpoints in canvas coords.
+            let start: { x: number; y: number }
+            if (isDraggingSource) {
+              // Source end follows the cursor; lock to a snap-target's
+              // bottom anchor if hovering one.
+              if (hoverTarget && positions[hoverTarget]) {
+                start = bottomAnchor({ x: positions[hoverTarget].x + offsetX, y: positions[hoverTarget].y })
+              } else {
+                start = { x: worldPointer.x + offsetX, y: worldPointer.y }
+              }
+            } else {
+              start = bottomAnchor({ x: sourcePos.x + offsetX, y: sourcePos.y })
+            }
 
             let end: { x: number; y: number }
-            let snapPreview: { x: number; y: number } | null = null
-            if (isDragging) {
-              end = { x: worldPointer.x + offsetX, y: worldPointer.y }
-              if (hoverTarget) {
-                const tpos = positions[hoverTarget]
-                if (tpos) snapPreview = topAnchor({ x: tpos.x + offsetX, y: tpos.y })
+            if (isDraggingTarget) {
+              if (hoverTarget && positions[hoverTarget]) {
+                end = topAnchor({ x: positions[hoverTarget].x + offsetX, y: positions[hoverTarget].y })
+              } else {
+                end = { x: worldPointer.x + offsetX, y: worldPointer.y }
               }
             } else if (edge.target) {
               const tpos = positions[edge.target]
@@ -437,75 +577,165 @@ export default function Lab() {
               end = { x: start.x, y: start.y + 90 }
             }
 
-            const dangling = !edge.target && !isDragging
-            const isGreen = dangling || (isDragging && !hoverTarget)
-            const stroke = isGreen ? '#34C759' : 'url(#lab-connected)'
-            const handleFill = isGreen ? '#34C759' : '#2B6BFF'
+            const dangling = !edge.target && !isDraggingTarget && !isDraggingSource
+            const greenStroke =
+              dangling ||
+              (isDraggingTarget && !hoverTarget) ||
+              (isDraggingSource && !hoverTarget)
+            const stroke = greenStroke ? '#34C759' : 'url(#lab-connected)'
+            const handleFill = greenStroke ? '#34C759' : '#2B6BFF'
+
+            const path = bezierPath(start.x, start.y, end.x, end.y)
+
+            // Show handles when:
+            //   • edge is in edit mode (both ends)
+            //   • edge is dangling (target end only — the green dot)
+            //   • edge is being dragged (the active end)
+            const showTargetHandle = inEdit || dangling || isDraggingTarget
+            const showSourceHandle = inEdit || isDraggingSource
 
             return (
-              <g key={edge.id} className="pointer-events-auto">
+              <g key={edge.id}>
+                {/* Invisible wide hit area for long-press to enter
+                    edit mode. PointerEvents="stroke" means clicks
+                    only register on (or near) the visible stroke. */}
                 <path
-                  d={bezierPath(start.x, start.y, end.x, end.y)}
+                  data-lab-interactive
+                  d={path}
+                  fill="none"
+                  stroke="transparent"
+                  strokeWidth={28}
+                  style={{ pointerEvents: 'stroke', cursor: 'pointer' }}
+                  onPointerDown={(e) => onLinePointerDown(edge.id, e)}
+                  onPointerMove={onLinePointerMove}
+                  onPointerUp={onLinePointerUp}
+                  onPointerCancel={onLinePointerUp}
+                />
+                {/* Visible stroke */}
+                <path
+                  d={path}
                   fill="none"
                   stroke={stroke}
-                  strokeWidth={3}
+                  strokeWidth={inEdit ? 4 : 3}
                   strokeLinecap="round"
                   filter="url(#lab-glow)"
-                  style={{ transition: isDragging ? 'none' : 'stroke 200ms' }}
+                  style={{
+                    pointerEvents: 'none',
+                    transition: dragging ? 'none' : 'stroke 200ms, stroke-width 200ms',
+                  }}
                 />
-                {/* Snap-locking dashed preview when the user is hovering
-                    a valid target — visually confirms the lock-on
-                    before they release. */}
-                {isDragging && snapPreview && (
+                {/* Snap preview line — green dashed segment from the
+                    snap anchor to the cursor while hovering a valid
+                    target. */}
+                {dragging?.edgeId === edge.id && hoverTarget && (
                   <line
-                    x1={snapPreview.x}
-                    y1={snapPreview.y}
-                    x2={end.x}
-                    y2={end.y}
+                    x1={dragging.which === 'target' ? topAnchor({ x: positions[hoverTarget].x + offsetX, y: positions[hoverTarget].y }).x : worldPointer.x + offsetX}
+                    y1={dragging.which === 'target' ? topAnchor({ x: positions[hoverTarget].x + offsetX, y: positions[hoverTarget].y }).y : worldPointer.y}
+                    x2={worldPointer.x + offsetX}
+                    y2={worldPointer.y}
                     stroke="#34C759"
                     strokeWidth={1.5}
                     strokeDasharray="4 4"
-                    opacity={0.6}
+                    opacity={0.55}
+                    style={{ pointerEvents: 'none' }}
                   />
                 )}
-                {/* Big transparent touch target on top of a smaller
-                    visible dot. Pointer-capture means once you start
-                    a drag, the dot keeps receiving move/up events
-                    until release — no need to keep the pointer
-                    inside the visible circle. */}
-                <circle
-                  data-lab-handle
-                  cx={end.x}
-                  cy={end.y}
-                  r={28 / Math.max(1, scale)}
-                  fill="transparent"
-                  className="cursor-grab active:cursor-grabbing"
-                  style={{ touchAction: 'none' }}
-                  onPointerDown={(e) => onHandlePointerDown(edge.id, e)}
-                  onPointerMove={onHandlePointerMove}
-                  onPointerUp={onHandlePointerUp}
-                  onPointerCancel={onHandlePointerUp}
-                />
-                <circle
-                  cx={end.x}
-                  cy={end.y}
-                  r={isDragging ? 14 : 10}
-                  fill={handleFill}
-                  stroke="#FFFFFF"
-                  strokeWidth={2.5}
-                  style={{
-                    filter: 'drop-shadow(0 2px 6px rgba(0,0,0,0.18))',
-                    transition: isDragging ? 'none' : 'r 150ms, fill 200ms',
-                    pointerEvents: 'none',
-                  }}
-                />
+
+                {/* Target-end handle (child) — visible if dangling or
+                    in edit. The dot itself; transparent hit area on
+                    top so touches don't miss. */}
+                {showTargetHandle && (
+                  <>
+                    <circle
+                      data-lab-interactive
+                      cx={end.x}
+                      cy={end.y}
+                      r={28 / Math.max(0.8, scale)}
+                      fill="transparent"
+                      style={{ touchAction: 'none', cursor: 'grab' }}
+                      onPointerDown={(e) => onHandlePointerDown(edge.id, 'target', e)}
+                      onPointerMove={onHandlePointerMove}
+                      onPointerUp={onHandlePointerUp}
+                      onPointerCancel={onHandlePointerUp}
+                    />
+                    <circle
+                      cx={end.x}
+                      cy={end.y}
+                      r={isDraggingTarget ? 13 : 10}
+                      fill={handleFill}
+                      stroke="#FFFFFF"
+                      strokeWidth={2.5}
+                      style={{
+                        filter: 'drop-shadow(0 2px 6px rgba(0,0,0,0.22))',
+                        transition: isDraggingTarget ? 'none' : 'r 150ms, fill 200ms',
+                        pointerEvents: 'none',
+                      }}
+                    />
+                  </>
+                )}
+
+                {/* Source-end handle (parent) — only in edit mode.
+                    Same shape as target handle. */}
+                {showSourceHandle && (
+                  <>
+                    <circle
+                      data-lab-interactive
+                      cx={start.x}
+                      cy={start.y}
+                      r={28 / Math.max(0.8, scale)}
+                      fill="transparent"
+                      style={{ touchAction: 'none', cursor: 'grab' }}
+                      onPointerDown={(e) => onHandlePointerDown(edge.id, 'source', e)}
+                      onPointerMove={onHandlePointerMove}
+                      onPointerUp={onHandlePointerUp}
+                      onPointerCancel={onHandlePointerUp}
+                    />
+                    <circle
+                      cx={start.x}
+                      cy={start.y}
+                      r={isDraggingSource ? 13 : 10}
+                      fill={handleFill}
+                      stroke="#FFFFFF"
+                      strokeWidth={2.5}
+                      style={{
+                        filter: 'drop-shadow(0 2px 6px rgba(0,0,0,0.22))',
+                        transition: isDraggingSource ? 'none' : 'r 150ms, fill 200ms',
+                        pointerEvents: 'none',
+                      }}
+                    />
+                  </>
+                )}
+
+                {/* Delete X — only in edit mode. Floats at the
+                    midpoint of the line. */}
+                {inEdit && (() => {
+                  const mx = (start.x + end.x) / 2
+                  const my = (start.y + end.y) / 2
+                  return (
+                    <g
+                      data-lab-interactive
+                      style={{ cursor: 'pointer', pointerEvents: 'all' }}
+                      onClick={() => deleteEdge(edge.id)}
+                    >
+                      <circle cx={mx} cy={my} r={16} fill="#FF3B30" stroke="#fff" strokeWidth={2.5}
+                        style={{ filter: 'drop-shadow(0 2px 6px rgba(0,0,0,0.25))' }} />
+                      <path
+                        d={`M ${mx - 6} ${my - 6} L ${mx + 6} ${my + 6} M ${mx + 6} ${my - 6} L ${mx - 6} ${my + 6}`}
+                        stroke="#fff"
+                        strokeWidth={2.5}
+                        strokeLinecap="round"
+                      />
+                    </g>
+                  )
+                })()}
               </g>
             )
           })}
         </svg>
 
-        {/* Member cards — the SAME MemberNode used in the production
-            tree, so the lab matches /tree visually pixel-for-pixel. */}
+        {/* Member cards — real MemberNode. Wrapped in a div carrying
+            data-lab-interactive + pointer handlers for tap vs.
+            long-press detection. */}
         {members.map((m) => {
           const pos = positions[m.id]
           if (!pos) return null
@@ -513,6 +743,7 @@ export default function Lab() {
           return (
             <motion.div
               key={m.id}
+              data-lab-interactive
               initial={{ opacity: 0, scale: 0.85 }}
               animate={{
                 opacity: 1,
@@ -528,13 +759,14 @@ export default function Lab() {
               }}
               className="absolute"
               style={{
-                // Lift the snap-target card visually above its
-                // siblings + give it a green halo so the user can
-                // confirm the lock-on before releasing.
                 filter: isSnapTarget ? 'drop-shadow(0 0 18px rgba(52,199,89,0.7))' : undefined,
                 zIndex: isSnapTarget ? 5 : 1,
+                touchAction: 'none',
               }}
-              onDoubleClick={() => spawnDanglingEdge(m.id)}
+              onPointerDown={(e) => onProfilePointerDown(m.id, e)}
+              onPointerMove={onProfilePointerMove}
+              onPointerUp={() => onProfilePointerUp(m.id)}
+              onPointerCancel={() => { profilePress.current && clearTimeout(profilePress.current.timerId); profilePress.current = null }}
             >
               <MemberNode
                 member={m}
@@ -547,12 +779,15 @@ export default function Lab() {
         })}
       </div>
 
-      {/* Bottom-left readout — shows live edge state so the user can
-          confirm drags actually mutate data. Kept outside the
-          transform so it stays a fixed-size HUD. */}
+      {/* Bottom-left live edges read-out — proves drags mutate data. */}
       <div className="absolute bottom-3 left-3 right-3 md:right-auto md:max-w-md z-20 bg-white/85 backdrop-blur rounded-2xl px-3 py-2 text-[11px] font-mono text-[#1C1C1E] shadow-sm border border-white/60 max-h-32 overflow-auto pointer-events-auto">
         <div className="font-bold mb-1 text-[#8E8E93]">
           {rtl ? 'מצב הקשרים (חי)' : 'Edges (live)'} · zoom {Math.round(scale * 100)}%
+          {editingEdge && (
+            <span className="ms-2 text-[#FF9F0A]">
+              {rtl ? `• עריכת ${editingEdge}` : `• editing ${editingEdge}`}
+            </span>
+          )}
         </div>
         {edges.map((edge) => {
           const a = memberById.get(edge.source)?.first_name ?? '?'
@@ -562,10 +797,49 @@ export default function Lab() {
           return (
             <div key={edge.id} className="leading-tight">
               <span className="text-[#8E8E93]">{edge.id}:</span> {a} → {b}
+              {editingEdge === edge.id && ' ✎'}
             </div>
           )
         })}
       </div>
+
+      {/* Profile modal — opens on short tap. Minimal: avatar + name +
+          gender + close button. Reusing MemberNode for the avatar
+          keeps the visual language consistent. */}
+      <AnimatePresence>
+        {profileMember && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="absolute inset-0 z-30 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+            onClick={() => setProfileMember(null)}
+            data-lab-interactive
+          >
+            <motion.div
+              initial={{ scale: 0.85, y: 20, opacity: 0 }}
+              animate={{ scale: 1, y: 0, opacity: 1 }}
+              exit={{ scale: 0.9, opacity: 0 }}
+              transition={{ type: 'spring', stiffness: 280, damping: 28 }}
+              onClick={(e) => e.stopPropagation()}
+              className="bg-white rounded-3xl shadow-xl p-6 max-w-xs w-[88%] flex flex-col items-center gap-3"
+            >
+              <MemberNode member={profileMember} size={110} dataMemberId={`modal-${profileMember.id}`} />
+              <div className="text-center text-[12px] text-[#8E8E93] mt-1">
+                {rtl
+                  ? `מין: ${profileMember.gender === 'female' ? 'נקבה' : 'זכר'}`
+                  : `Gender: ${profileMember.gender}`}
+              </div>
+              <button
+                onClick={() => setProfileMember(null)}
+                className="mt-2 bg-[#007AFF] hover:bg-[#0066DD] text-white rounded-full px-5 py-2 text-[13px] font-semibold transition"
+              >
+                {rtl ? 'סגור' : 'Close'}
+              </button>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   )
 }


### PR DESCRIPTION
## What

User feedback: "can't undo or change a line after positioning", "single tap on profile should open the person; only long-press should offer to create/change a line".

## New interaction model

**Profile card**
- **Tap** → open profile modal (avatar + name + gender + close button)
- **Long-press 500ms** → spawn a new dangling edge from this person + haptic ping

**Line (connector)**
- **Long-press 500ms** → enter EDIT mode: handles appear at BOTH endpoints; a red X delete button floats at the midpoint

**Handle**
- **Drag** → re-target that endpoint. Target end snaps to a member's TOP anchor; source end snaps to a member's BOTTOM anchor. Released over empty space → dangling (green)

**Empty canvas**
- **Tap** → exit edit mode
- **Drag / pinch** → pan + zoom

## Implementation notes

- Long-press detection cancels if the pointer drifts >10px so a pan gesture starting on a card doesn't accidentally trigger "create edge"
- Lines get a transparent 28px hit-area path on top of the visible 3px stroke — long-press registers even on thin curves
- Both handles use Pointer Events with `setPointerCapture` so they own the gesture once grabbed; outer pan handler checks for `[data-lab-interactive]` and bails out
- Anchor offsets moved 4px outside the card so the source handle isn't hidden under MemberNode chrome

## Verified

Playwright on desktop:
- Tap on `c1` → profile modal opens
- Long-press on `c2` → new dangling edge spawned
- Long-press on `e1` line → edit mode active; 4 interactive handles visible (e1 source + e1 target + e2 dangling + new dangling)
- HUD shows `✎` + "editing e1" indicator

https://claude.ai/code/session_01LppGwaDmEuFc7T6KggF5PJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppGwaDmEuFc7T6KggF5PJ)_