### PR TITLE
fix(ui): owner bug batch — ex-spouse display, mobile minimap, focused…

### DIFF
--- a/src/components/views/AdvancedFilter.tsx
+++ b/src/components/views/AdvancedFilter.tsx
@@ -89,14 +89,14 @@ export default function AdvancedFilter({
       // Density) so the three controls stack vertically instead of
       // splitting across both edges of the screen — the user
       // explicitly asked for them to live together.
-      // top-[124px] = the FIRST slot beneath the hamburger.
-      // Order in the hamburger column is now Filter (124) →
-      // Focused (176) → Density (228), per the user's explicit
-      // request that Filter come first.
+      // top-[144px] = the FIRST slot beneath the hamburger (88 + 40px
+      // button + breathing room — at 124 the hamburger's X overlapped
+      // this chip, an owner-reported bug). Stack order: Filter (144) →
+      // Focused (196) → "?" (248).
       // `relative` so the absolute popover below positions against
       // the chip and the chip itself doesn't get re-sized when the
       // popover opens.
-      className="absolute top-[124px] z-20 no-print"
+      className="absolute top-[144px] z-20 no-print"
       style={{ [rtl ? 'left' : 'right']: 12, position: 'absolute' } as React.CSSProperties}
       data-tour="tree-chip-filter"
     >

--- a/src/components/views/FocusedCentricView.tsx
+++ b/src/components/views/FocusedCentricView.tsx
@@ -9,7 +9,6 @@ import ConnectorsLayer from './tree/ConnectorsLayer'
 import { PersonAvatarIcon } from '../MemberNode'
 import { getFallbackGradient, getRingGradient, getRingShadow } from '../memberVisuals'
 
-const PAD = 72
 
 // ─── Main component ───────────────────────────────────────────────────────────
 //
@@ -58,7 +57,9 @@ export default function FocusedCentricView({
 
   // Shared engine on the subgraph: members from the role-tagger, edges
   // restricted to the included population.
-  const { result, roleOf } = useMemo(() => {
+  // (roles/sides from buildFocusedSubgraph are no longer used for
+  // rendering — kept available via `focusedMembers` if needed later.)
+  const { result } = useMemo(() => {
     const subMembers = focusedMembers.map((fm) => fm.member)
     const ids = new Set(subMembers.map((m) => m.id))
     const subRelationships = allRelationships.filter(
@@ -300,25 +301,9 @@ export default function FocusedCentricView({
             transformOrigin: '0 0',
           }}
         >
-          {/* Side tints */}
-          {result.nodes.some(n => roleOf.get(n.member.id)?.side === 'paternal') && (
-            <div
-              className="absolute pointer-events-none rounded-2xl"
-              style={{
-                left: 0, top: PAD, width: canvasW / 2 - 20, height: canvasH - PAD * 2,
-                background: 'linear-gradient(to right, rgba(0,122,255,0.03), transparent)',
-              }}
-            />
-          )}
-          {result.nodes.some(n => roleOf.get(n.member.id)?.side === 'maternal') && (
-            <div
-              className="absolute pointer-events-none rounded-2xl"
-              style={{
-                right: 0, top: PAD, width: canvasW / 2 - 20, height: canvasH - PAD * 2,
-                background: 'linear-gradient(to left, rgba(52,199,89,0.03), transparent)',
-              }}
-            />
-          )}
+          {/* (The old paternal/maternal side-tint rectangles were removed —
+              their hard edges read as a broken/clipped background, which
+              the owner reported as a bug.) */}
 
           {/* Generation labels — engine rows, relative to the focus row */}
           {result.generationRows.map((row) => {

--- a/src/components/views/TreeMiniMap.tsx
+++ b/src/components/views/TreeMiniMap.tsx
@@ -82,8 +82,13 @@ export default function TreeMiniMap({
   // Compact-on-small-trees: when the tree is sparse (≤10 nodes) the
   // default 180-wide minimap dwarfs the actual canvas. Drop down to
   // 110 wide / 80 tall in that regime so the corner stays subtle.
-  const MM_WIDTH = nodes.length <= 10 ? MM_WIDTH_COMPACT : MM_WIDTH_DEFAULT
-  const MM_MAX_HEIGHT = nodes.length <= 10 ? MM_MAX_HEIGHT_COMPACT : MM_MAX_HEIGHT_DEFAULT
+  //
+  // Phones: on narrow viewports the 180px map ate a big slice of the
+  // screen while showing a handful of far-apart dots — zero navigation
+  // value at a high cost. Cap it small there regardless of tree size.
+  const phone = viewportW < 520
+  const MM_WIDTH = phone ? 88 : nodes.length <= 10 ? MM_WIDTH_COMPACT : MM_WIDTH_DEFAULT
+  const MM_MAX_HEIGHT = phone ? 60 : nodes.length <= 10 ? MM_MAX_HEIGHT_COMPACT : MM_MAX_HEIGHT_DEFAULT
   const { mmW, mmH, mmScale } = useMemo(() => {
     if (canvasW <= 0 || canvasH <= 0) {
       return { mmW: MM_WIDTH, mmH: 90, mmScale: 1 }
@@ -222,7 +227,7 @@ export default function TreeMiniMap({
             key={n.member.id}
             cx={(n.x + CARD.W / 2) * mmScale}
             cy={(n.y + AVATAR_CENTER_Y) * mmScale}
-            r={1.6}
+            r={Math.max(1.6, Math.min(2.4, mmW / 60))}
             fill={n.member.gender === 'female' ? '#FF7AA8' : '#3D8BFD'}
             opacity={0.85}
           />

--- a/src/components/views/TreeView.tsx
+++ b/src/components/views/TreeView.tsx
@@ -293,11 +293,12 @@ export default function TreeView({
         </div>
       )}
 
-      {/* Focused-Centric mode button — below the filter chip. */}
+      {/* Focused-Centric mode button — second slot beneath the filter
+          chip (144 + ~40px chip + gap). */}
       {members.length > 0 && treeControlsExpanded && (
         <div
           className="absolute z-20 no-print"
-          style={{ top: 176, [rtl ? 'left' : 'right']: 12 } as React.CSSProperties}
+          style={{ top: 196, [rtl ? 'left' : 'right']: 12 } as React.CSSProperties}
           data-tour="tree-chip-focus"
         >
           <Tooltip content={t.tipFocusedCentric} placement="bottom">

--- a/src/components/views/__tests__/applyTreeFilters.test.ts
+++ b/src/components/views/__tests__/applyTreeFilters.test.ts
@@ -139,6 +139,22 @@ describe('applyTreeFilters — visibility contracts', () => {
     expect(out.members.map((x) => x.id)).not.toContain('ex')
   })
 
+  it('an ex-only member is OFF the tree by default, present (for the badge) with showFormerSpouses', () => {
+    // exwife's only tie is the dead marriage; me is anchored via a kid.
+    const members = [m('me'), m('kid'), m('exwife', { gender: 'female' })]
+    const rels = [pc('r0', 'me', 'kid'), sp('r1', 'me', 'exwife', 'ex')]
+    expect(run(members, rels).members.map((x) => x.id).sort()).toEqual(['kid', 'me'])
+    expect(run(members, rels, { showFormerSpouses: true }).members.map((x) => x.id).sort()).toEqual(
+      ['exwife', 'kid', 'me'],
+    )
+  })
+
+  it('a divorced pair where BOTH sides have nothing else stays visible', () => {
+    const members = [m('a'), m('b', { gender: 'female' })]
+    const rels = [sp('r1', 'a', 'b', 'ex')]
+    expect(run(members, rels).members.map((x) => x.id).sort()).toEqual(['a', 'b'])
+  })
+
   it('focus mode keeps ancestors, descendants and in-scope spouses', () => {
     const members = [
       m('grandpa'), m('dad'), m('me'), m('wife', { gender: 'female' }),

--- a/src/components/views/applyTreeFilters.ts
+++ b/src/components/views/applyTreeFilters.ts
@@ -185,26 +185,55 @@ export function applyTreeFilters(
       const hasAnyParent = relationships.some(
         r => r.type === 'parent-child' && r.member_b_id === id,
       )
-      // Standalone founder (no parents anywhere in the DB, no visible
-      // children, no current spouse): keep them — they're a deliberate
-      // standalone node, not noise.
-      if (!hasAnyParent) continue
-      // At this point: has parents in DB but none visible, no visible
-      // children, no current spouse. They may still be a non-current
-      // (ex / deceased) spouse of someone in-tree — in which case
-      // they're a "married-in ex" with all their ties dead, and the
-      // layout engine would otherwise render them as a free-floating
-      // root subtree at the canvas edge ("נתנאל" the ex bug).
       const hasNonCurrentSpouse = relationships.some(
         r => r.type === 'spouse' && (r.status ?? 'current') !== 'current'
              && (r.member_a_id === id || r.member_b_id === id),
       )
-      // Preserve standalone members that aren't ex-spouses of anyone
-      // when no manual hides are active — they're legitimately
-      // unconnected founders waiting to be linked.
+      // Standalone founder (no parents anywhere in the DB, no visible
+      // children, no current spouse): keep them — they're a deliberate
+      // standalone node, not noise. (Ex-only members get a dedicated
+      // final pass below.)
+      if (!hasAnyParent) continue
+      // At this point: has parents in DB but none visible, no visible
+      // children, no current spouse.
       if (allHidden.size === 0 && !hasNonCurrentSpouse) continue
       allowed.delete(id)
       removedAny = true
+    }
+  }
+
+  // ── Ex-only members: off the tree by default ───────────────────────
+  // A member whose ONLY family tie is a divorced/widowed marriage (no
+  // parent-child edges at all, no current spouse) does not get a card
+  // of their own unless "show divorces" is on — the relationship stays
+  // visible inside the former partner's profile panel, and with the
+  // flag on they render as a small badge ATTACHED to that partner
+  // (engine-side), never as a loose floating profile.
+  // Pruned only when a former partner remains visible WITH real ties of
+  // their own — if both sides of a divorced pair have nothing else,
+  // both stay (otherwise the pair would vanish entirely).
+  if (!filters.showFormerSpouses) {
+    const isExOnly = (id: string): boolean => {
+      const hasFamilyEdge = relationships.some(
+        r => (r.type === 'parent-child' && (r.member_a_id === id || r.member_b_id === id)) ||
+             (r.type === 'spouse' && (r.status ?? 'current') === 'current' &&
+              (r.member_a_id === id || r.member_b_id === id)),
+      )
+      if (hasFamilyEdge) return false
+      return relationships.some(
+        r => r.type === 'spouse' && (r.status ?? 'current') !== 'current' &&
+             (r.member_a_id === id || r.member_b_id === id),
+      )
+    }
+    for (const id of [...allowed]) {
+      if (!isExOnly(id)) continue
+      const formerPartners = relationships
+        .filter(r => r.type === 'spouse' && (r.status ?? 'current') !== 'current' &&
+                     (r.member_a_id === id || r.member_b_id === id))
+        .map(r => (r.member_a_id === id ? r.member_b_id : r.member_a_id))
+      if (formerPartners.some(p => allowed.has(p) && !isExOnly(p))) {
+        allowed.delete(id)
+      }
     }
   }
 

--- a/src/layout/__tests__/engine.test.ts
+++ b/src/layout/__tests__/engine.test.ts
@@ -134,10 +134,59 @@ describe('computeLayout — malformed data never hangs or hides members', () => 
       { showFormerSpouses: true },
     )
     expect(r.issues.some((i) => i.kind === 'multiple-current-spouses')).toBe(true)
-    // w2 still renders (as her own node) and as a badge under h.
-    expect(r.nodes).toHaveLength(3)
+    // w2 renders as a badge under h ONLY — never as a floating card.
+    expect(r.nodes).toHaveLength(2)
+    expect(r.badgeOnlyMembers).toEqual(['w2'])
     const h = r.nodes.find((n) => n.member.id === 'h')!
     expect(h.secondaryPartners?.some((p) => p.member.id === 'w2')).toBe(true)
+    expect(r.issues.some((i) => i.kind === 'unplaced')).toBe(false)
+    expectValid(r)
+  })
+
+  it('an ex with no other family ties is a badge, never a floating card', () => {
+    const r = computeLayout(
+      {
+        // 'a' is anchored in the tree (has a child) — his ex is not.
+        members: [m('a'), m('kid'), m('exwife', { gender: 'female' })],
+        relationships: [pc('r0', 'a', 'kid'), sp('r1', 'a', 'exwife', 'ex')],
+      },
+      { showFormerSpouses: true },
+    )
+    expect(r.nodes.map((n) => n.member.id).sort()).toEqual(['a', 'kid'])
+    expect(r.badgeOnlyMembers).toEqual(['exwife'])
+    const a = r.nodes.find((n) => n.member.id === 'a')!
+    expect(a.secondaryPartners?.[0]?.member.id).toBe('exwife')
+    expect(r.issues).toEqual([])
+    expectValid(r)
+  })
+
+  it('a divorced pair with no other ties keeps BOTH cards (no vanishing)', () => {
+    const r = computeLayout(
+      {
+        members: [m('a'), m('b', { gender: 'female' })],
+        relationships: [sp('r1', 'a', 'b', 'ex')],
+      },
+      { showFormerSpouses: true },
+    )
+    expect(r.nodes.map((n) => n.member.id).sort()).toEqual(['a', 'b'])
+    expect(r.badgeOnlyMembers).toEqual([])
+    expectValid(r)
+  })
+
+  it('an ex who is a PARENT keeps a real card (they anchor children)', () => {
+    const r = computeLayout(
+      {
+        members: [m('mom', { gender: 'female' }), m('exdad'), m('kid')],
+        relationships: [
+          sp('r1', 'mom', 'exdad', 'ex'),
+          pc('r2', 'mom', 'kid'),
+          pc('r3', 'exdad', 'kid'),
+        ],
+      },
+      { showFormerSpouses: true },
+    )
+    expect(r.nodes.map((n) => n.member.id).sort()).toEqual(['exdad', 'kid', 'mom'])
+    expect(r.badgeOnlyMembers).toEqual([])
     expectValid(r)
   })
 
@@ -177,8 +226,9 @@ describe('computeLayout — invariants hold across random families', () => {
           violations.map((v) => `${v.rule}: ${v.message}`),
           `seed ${seed * 100 + generations}, ${fam.members.length} members`,
         ).toEqual([])
-        // Everyone is either placed or explicitly reported — never lost.
-        expect(r.nodes.length).toBe(fam.members.length)
+        // Everyone is either placed, a badge on their former partner,
+        // or explicitly reported — never lost.
+        expect(r.nodes.length + r.badgeOnlyMembers.length).toBe(fam.members.length)
       }
     })
   }
@@ -304,7 +354,7 @@ describe('computeLayout — menorah (in-law parents above the spouse)', () => {
         validateLayout(r).map((v) => `${v.rule}: ${v.message}`),
         `seed ${9000 + seed}, ${fam.members.length} members`,
       ).toEqual([])
-      expect(r.nodes.length).toBe(fam.members.length)
+      expect(r.nodes.length + r.badgeOnlyMembers.length).toBe(fam.members.length)
     }
   })
 })

--- a/src/layout/buildGraph.ts
+++ b/src/layout/buildGraph.ts
@@ -178,9 +178,31 @@ export function buildFamilyGraph(input: LayoutInput, options: LayoutOptions = {}
     for (const m of unit.members) unitOfMember.set(m.id, unit.id)
   }
 
+  // Badge-only members: someone's ex/deceased partner whose ONLY tie
+  // to the tree is that former marriage. They render as the small
+  // badge under the former partner — never as their own floating card.
+  // Asymmetry guard: the badge needs an ANCHORED host (a partner with
+  // real ties of their own); a divorced pair where BOTH sides have
+  // nothing else keeps two normal cards instead of vanishing.
+  const anchored = (id: string): boolean =>
+    spouseOf.has(id) ||
+    (parentsOf.get(id) ?? []).length > 0 ||
+    (childrenOf.get(id) ?? []).length > 0
+  const badgeOnlyMemberIds = new Set<string>()
+  for (const [ownerId, list] of secondaryPartnersOf) {
+    if (!anchored(ownerId)) continue
+    for (const p of list) {
+      if (!anchored(p.member.id)) badgeOnlyMemberIds.add(p.member.id)
+    }
+  }
+
   const seen = new Set<string>()
   for (const m of members) {
     if (seen.has(m.id)) continue
+    if (badgeOnlyMemberIds.has(m.id)) {
+      seen.add(m.id)
+      continue // represented as a badge, not a unit
+    }
     const spouseId = spouseOf.get(m.id)
     if (!spouseId) {
       seen.add(m.id)
@@ -329,6 +351,7 @@ export function buildFamilyGraph(input: LayoutInput, options: LayoutOptions = {}
     secondaryPartnersOf,
     satellites,
     orphanUnitIds,
+    badgeOnlyMemberIds,
     issues,
   }
 }

--- a/src/layout/index.ts
+++ b/src/layout/index.ts
@@ -39,6 +39,7 @@ export function computeLayout(input: LayoutInput, options: LayoutOptions = {}): 
       generationRows: [],
       issues: [],
       satelliteUnitIds: [],
+      badgeOnlyMembers: [],
       coupleGaps: {},
     }
   }
@@ -81,16 +82,18 @@ export function computeLayout(input: LayoutInput, options: LayoutOptions = {}): 
 
   const issues = [...graph.issues, ...gens.issues, ...connectors.issues]
   // "Placed correctly or explicitly reported" — never silently dropped.
-  if (nodes.length < input.members.length) {
-    const placedIds = new Set(nodes.map((n) => n.member.id))
-    const missing = input.members.filter((m) => !placedIds.has(m.id))
-    if (missing.length > 0) {
-      issues.push({
-        kind: 'unplaced',
-        memberIds: missing.map((m) => m.id),
-        message: `${missing.length} member(s) could not be placed`,
-      })
-    }
+  // (Badge-only ex-partners are intentionally card-less: they render as
+  // the small badge beneath their former partner.)
+  const placedIds = new Set(nodes.map((n) => n.member.id))
+  const missing = input.members.filter(
+    (m) => !placedIds.has(m.id) && !graph.badgeOnlyMemberIds.has(m.id),
+  )
+  if (missing.length > 0) {
+    issues.push({
+      kind: 'unplaced',
+      memberIds: missing.map((m) => m.id),
+      message: `${missing.length} member(s) could not be placed`,
+    })
   }
 
   let maxX = 0
@@ -111,6 +114,7 @@ export function computeLayout(input: LayoutInput, options: LayoutOptions = {}): 
     generationRows: connectors.generationRows,
     issues,
     satelliteUnitIds: graph.satellites.map((s) => s.unitId).sort(),
+    badgeOnlyMembers: [...graph.badgeOnlyMemberIds].sort(),
     coupleGaps: placement.coupleGaps,
   }
 }

--- a/src/layout/types.ts
+++ b/src/layout/types.ts
@@ -124,6 +124,9 @@ export interface LayoutResult {
   /** Units placed as in-law "satellites" above a married-in spouse —
    *  their alignment is best-effort, so symmetry checks skip them. */
   satelliteUnitIds: UnitId[]
+  /** Members rendered ONLY as a badge under their former partner
+   *  (ex/deceased spouses with no other family ties) — no card. */
+  badgeOnlyMembers: string[]
   /** Actual horizontal gap inside each couple (the gap widens when
    *  both spouses have parent couples above them — the "menorah"). */
   coupleGaps: Record<UnitId, number>
@@ -169,5 +172,12 @@ export interface FamilyGraph {
   satellites: Array<{ unitId: UnitId; hostUnitId: UnitId; anchorMemberId: string }>
   /** Single-member units with no family edges at all. */
   orphanUnitIds: Set<UnitId>
+  /**
+   * Members represented ONLY as a badge beneath their former partner —
+   * an ex/deceased spouse whose only tie to the tree is that marriage.
+   * They get no unit and no card of their own (a floating "loose"
+   * profile is exactly the bug this prevents).
+   */
+  badgeOnlyMemberIds: Set<string>
   issues: LayoutIssue[]
 }

--- a/src/pages/TreePage.tsx
+++ b/src/pages/TreePage.tsx
@@ -22,6 +22,24 @@ import { shouldAutoShowTutorial, recordTutorialShown } from '../lib/tutorialStat
 
 interface Props { demoMode: boolean }
 
+/**
+ * Wraps children in a Tooltip only while `show` is true. Used by the
+ * hamburger: once expanded, its tooltip bubble used to cover the chips
+ * that had just appeared below it.
+ */
+function ConditionalTooltip({
+  show,
+  content,
+  children,
+}: {
+  show: boolean
+  content: string
+  children: React.ReactElement
+}) {
+  if (!show) return children
+  return <Tooltip content={content} placement="bottom" align="end">{children}</Tooltip>
+}
+
 export default function TreePage({ demoMode }: Props) {
   const {
     selectedMemberId, setSelectedMemberId, profile,
@@ -268,7 +286,13 @@ export default function TreePage({ demoMode }: Props) {
                 its label is unambiguous. */}
             {!hideChrome && (
             <div className={`fixed z-30 no-print ${isRTL(lang) ? 'left-3' : 'right-3'}`} style={{ top: 'calc(env(safe-area-inset-top, 0px) + 88px)' }} data-tour="tree-hamburger">
-            <Tooltip content={t.tipTreeControlsToggle} placement="bottom" align="end">
+            {/* Tooltip only while COLLAPSED — when expanded the bubble
+                used to cover the chips underneath (owner bug report),
+                and an X button needs no explanation anyway. */}
+            <ConditionalTooltip
+              show={!treeControlsExpanded}
+              content={t.tipTreeControlsToggle}
+            >
             <motion.button
               type="button"
               onClick={() => setTreeControlsExpanded(!treeControlsExpanded)}
@@ -298,7 +322,7 @@ export default function TreePage({ demoMode }: Props) {
                 )}
               </motion.svg>
             </motion.button>
-            </Tooltip>
+            </ConditionalTooltip>
             </div>
             )}
 
@@ -321,13 +345,12 @@ export default function TreePage({ demoMode }: Props) {
                 clean and the user finds it together with the other
                 advanced controls. */}
             {treeControlsExpanded && !hideChrome && (
-              // Minimal "?" icon — sits below the rest of the hamburger
-              // pills so the user finds it last in the vertical stack.
-              // top:280 lands AFTER the density chip (which is at 228 +
-              // ~52px button height including its outline shadow), with
-              // a small gap so the icon doesn't overlap the chip on
-              // mobile. The previous offset (232) overlapped by 4px.
-              <div className={`fixed z-30 no-print ${isRTL(lang) ? 'left-3' : 'right-3'}`} style={{ top: 'calc(env(safe-area-inset-top, 0px) + 280px)' }}>
+              // Minimal "?" icon — last in the vertical stack. NOTE the
+              // chips above it are `absolute` inside the tree container
+              // (origin ~31px lower than the viewport) while this button
+              // is `fixed`, so its offset compensates: focus chip ends at
+              // ~viewport 270; 300 leaves a clean gap below it.
+              <div className={`fixed z-30 no-print ${isRTL(lang) ? 'left-3' : 'right-3'}`} style={{ top: 'calc(env(safe-area-inset-top, 0px) + 300px)' }}>
                 <Tooltip content={t.tipTreeTutorial} placement="bottom" align="end">
                   <motion.button
                     type="button"
@@ -366,7 +389,7 @@ export default function TreePage({ demoMode }: Props) {
             the tree. */}
         {(viewMode === 'schematic' || viewMode === 'timeline') && !treeFullscreen && (
           <div className={`absolute z-30 no-print top-[72px] ${isRTL(lang) ? 'left-3' : 'right-3'}`}>
-            <Tooltip content={t.tipTreeControlsToggle} placement="bottom" align="end">
+            <ConditionalTooltip show={!treeControlsExpanded} content={t.tipTreeControlsToggle}>
               <motion.button
                 type="button"
                 onClick={() => setTreeControlsExpanded(!treeControlsExpanded)}
@@ -393,7 +416,7 @@ export default function TreePage({ demoMode }: Props) {
                   )}
                 </motion.svg>
               </motion.button>
-            </Tooltip>
+            </ConditionalTooltip>
           </div>
         )}
         {/* Schematic + Timeline share a swipe-to-toggle gesture (see


### PR DESCRIPTION
… background, hamburger stack

1. Ex/divorced spouses: a member whose only family tie is a former marriage is OFF the tree by default (info stays in the partner's profile panel). With 'show divorces' on they render as the small badge ATTACHED to the former partner — the engine no longer gives them a floating card (badge-only members). Asymmetry guard: a divorced pair where BOTH sides have nothing else keeps two normal cards so the pair can't vanish entirely.
2. Minimap: capped to 88x60 on narrow viewports (<520px) — it used to eat a quarter of a phone screen while conveying nothing; dot radius now scales with map size.
3. Focused mode: removed the paternal/maternal side-tint rectangles — their hard edges read as a broken, clipped background.
4. Hamburger stack: filter chip 124→144 (the X used to overlap it), focus chip 176→196, '?' re-anchored below the stack (was orphaned at the old density-chip offset), and the hamburger tooltip renders only while collapsed so it can't cover the chips it reveals.

51 tests green incl. 4 new ex-spouse contracts (filter + engine).