### PR TITLE
feat(ux): owner bug batch 2 - help hub, admin reports, 10-gen demo seed, mobile back

### DIFF
--- a/migrations/012_feedback.sql
+++ b/migrations/012_feedback.sql
@@ -1,0 +1,50 @@
+-- ============================================================
+-- Migration 012: feedback table (help "?" → report to admin)
+-- ------------------------------------------------------------
+-- Why this exists
+--   The tree page's help menu gained a "report a bug / ask the
+--   admin" form. Reports need to land somewhere the admin can
+--   actually see them — the new "reports" tab in the admin
+--   dashboard reads from this table.
+--
+-- Model
+--   One row per submission. `author_name` is denormalised (same
+--   rationale as member_notes) so a report stays readable after
+--   the author's profile is renamed or deleted. `context` stores
+--   the route hash the report was sent from, to help reproduce.
+--
+-- Access
+--   * Any authenticated user can INSERT their own report.
+--   * Only admins can SELECT / UPDATE / DELETE (regular users
+--     never read other people's reports; their own submission is
+--     kept optimistically client-side).
+--
+-- Safety
+--   Idempotent: `if not exists` + drop-then-create policies.
+-- ============================================================
+
+create table if not exists public.feedback (
+  id          uuid primary key default gen_random_uuid(),
+  author_id   uuid references public.profiles(id) on delete set null,
+  author_name text not null default '',
+  category    text not null check (category in ('bug', 'question')),
+  body        text not null,
+  context     text,
+  status      text not null default 'open' check (status in ('open', 'resolved')),
+  created_at  timestamptz not null default now()
+);
+
+alter table public.feedback enable row level security;
+
+drop policy if exists "fb_insert_self"  on public.feedback;
+drop policy if exists "fb_select_admin" on public.feedback;
+drop policy if exists "fb_update_admin" on public.feedback;
+drop policy if exists "fb_delete_admin" on public.feedback;
+
+create policy "fb_insert_self" on public.feedback for insert
+  with check (auth.role() = 'authenticated' and author_id = auth.uid());
+create policy "fb_select_admin" on public.feedback for select using (public.is_admin(auth.uid()));
+create policy "fb_update_admin" on public.feedback for update using (public.is_admin(auth.uid()));
+create policy "fb_delete_admin" on public.feedback for delete using (public.is_admin(auth.uid()));
+
+create index if not exists feedback_status_idx on public.feedback(status);

--- a/schema.sql
+++ b/schema.sql
@@ -238,6 +238,22 @@ create table if not exists public.member_notes (
 );
 
 -- ============================================================
+-- FEEDBACK — bug reports / questions sent from the help "?" menu
+-- ============================================================
+-- `author_name` denormalised like member_notes; `context` stores the
+-- route hash the report was sent from. Admin-only reads (see RLS).
+create table if not exists public.feedback (
+  id          uuid primary key default uuid_generate_v4(),
+  author_id   uuid references public.profiles(id) on delete set null,
+  author_name text not null default '',
+  category    text not null check (category in ('bug', 'question')),
+  body        text not null,
+  context     text,
+  status      text not null default 'open' check (status in ('open', 'resolved')),
+  created_at  timestamptz not null default now()
+);
+
+-- ============================================================
 -- ROW-LEVEL SECURITY
 -- ============================================================
 
@@ -460,6 +476,19 @@ create policy "notes_update_self"  on public.member_notes for update using (auth
 create policy "notes_delete_self"  on public.member_notes for delete using (author_id = auth.uid());
 create policy "notes_delete_admin" on public.member_notes for delete using (public.is_admin(auth.uid()));
 
+-- ─── FEEDBACK ─────────────────────────────────────────────
+-- Users write their own reports; only admins read / triage them.
+alter table public.feedback enable row level security;
+drop policy if exists "fb_insert_self"  on public.feedback;
+drop policy if exists "fb_select_admin" on public.feedback;
+drop policy if exists "fb_update_admin" on public.feedback;
+drop policy if exists "fb_delete_admin" on public.feedback;
+create policy "fb_insert_self" on public.feedback for insert
+  with check (auth.role() = 'authenticated' and author_id = auth.uid());
+create policy "fb_select_admin" on public.feedback for select using (public.is_admin(auth.uid()));
+create policy "fb_update_admin" on public.feedback for update using (public.is_admin(auth.uid()));
+create policy "fb_delete_admin" on public.feedback for delete using (public.is_admin(auth.uid()));
+
 -- ============================================================
 -- INDEXES
 -- ============================================================
@@ -471,6 +500,7 @@ create index if not exists notes_member_idx        on public.member_notes(member
 create index if not exists er_status_idx           on public.edit_requests(status);
 create index if not exists ar_status_idx           on public.access_requests(status);
 create index if not exists inv_code_idx            on public.tree_invites(code);
+create index if not exists feedback_status_idx     on public.feedback(status);
 
 -- ============================================================
 -- DONE

--- a/scripts/seed-demo-tree.ts
+++ b/scripts/seed-demo-tree.ts
@@ -1,0 +1,205 @@
+/**
+ * Replace the LIVE demo tree's population with the 10-generation pilot
+ * dataset from src/data/adlerFamily.ts (single source of truth — edit
+ * the seed there, never here).
+ *
+ * Usage:
+ *   npx tsx scripts/seed-demo-tree.ts --tree "משפחת אדלר" --dry-run
+ *   npx tsx scripts/seed-demo-tree.ts --tree "משפחת אדלר" --yes
+ *
+ * What it does (inside ONE transaction):
+ *   1. Resolves the target tree by name (must match exactly one row).
+ *   2. Deletes all relationships touching the tree's current members,
+ *      then the members themselves (the old placeholder population).
+ *   3. Inserts the seed members with fresh UUIDs (created_by = the
+ *      tree's owner) and re-links all seed relationships.
+ *
+ * Safety:
+ *   * Refuses to run without --yes (or with --dry-run, which only
+ *     prints what WOULD happen).
+ *   * Take a snapshot first: npx tsx scripts/export-snapshot.ts
+ */
+import { Client } from 'pg'
+import { readFileSync, writeFileSync, existsSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+import { ADLER_MEMBERS, ADLER_RELATIONSHIPS } from '../src/data/adlerFamily'
+
+const args = process.argv.slice(2)
+function argValue(flag: string): string | null {
+  const i = args.indexOf(flag)
+  return i >= 0 && args[i + 1] ? args[i + 1] : null
+}
+const treeName = argValue('--tree')
+const dryRun = args.includes('--dry-run')
+const confirmed = args.includes('--yes')
+
+if (!treeName) {
+  console.error('Usage: tsx scripts/seed-demo-tree.ts --tree "<tree name>" [--dry-run | --yes]')
+  process.exit(1)
+}
+if (!dryRun && !confirmed) {
+  console.error('Refusing to modify the live DB without --yes (use --dry-run to preview).')
+  process.exit(1)
+}
+
+// ── Connection (same strategy as run-migration.ts) ───────────────────
+const PROJECT_REF = 'wkbdqdytfjycbbcnzjuv'
+const DB_PASSWORD = 'Yakiradler1123'
+const here = dirname(fileURLToPath(import.meta.url))
+const cacheFile = join(here, '.region-cache')
+
+async function tryConnect(opts: { host: string; port: number; user: string; label: string }): Promise<Client | null> {
+  const c = new Client({
+    host: opts.host,
+    port: opts.port,
+    database: 'postgres',
+    user: opts.user,
+    password: DB_PASSWORD,
+    ssl: { rejectUnauthorized: false },
+    connectionTimeoutMillis: 6000,
+  })
+  try {
+    await c.connect()
+    console.log(`✓ Connected via ${opts.label}`)
+    return c
+  } catch (e) {
+    console.log(`  ✗ ${opts.label}: ${(e instanceof Error ? e.message : String(e)).slice(0, 110)}`)
+    try { await c.end() } catch { /* ignore */ }
+    return null
+  }
+}
+
+async function connect(): Promise<Client> {
+  const direct = await tryConnect({
+    host: `db.${PROJECT_REF}.supabase.co`,
+    port: 5432,
+    user: 'postgres',
+    label: `direct db.${PROJECT_REF}.supabase.co:5432`,
+  })
+  if (direct) return direct
+  const cached = process.env.SUPABASE_POOLER_REGION
+    ?? (existsSync(cacheFile) ? readFileSync(cacheFile, 'utf8').trim() : '')
+  if (cached) {
+    const [prefix, ...rest] = cached.split(':')
+    const [poolerPrefix, region] = rest.length ? [prefix, rest.join(':')] : ['aws-1', cached]
+    const c = await tryConnect({
+      host: `${poolerPrefix}-${region}.pooler.supabase.com`,
+      port: 6543,
+      user: `postgres.${PROJECT_REF}`,
+      label: `pooler ${poolerPrefix}-${region} (cached)`,
+    })
+    if (c) return c
+  }
+  const regions = [
+    'eu-central-1', 'eu-central-2', 'eu-west-1', 'eu-west-2', 'eu-west-3',
+    'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2',
+    'ap-southeast-1', 'ap-southeast-2', 'ap-northeast-1', 'ap-northeast-2',
+    'ap-south-1', 'sa-east-1', 'ca-central-1',
+  ]
+  for (const poolerPrefix of ['aws-1', 'aws-0']) {
+    for (const r of regions) {
+      const c = await tryConnect({
+        host: `${poolerPrefix}-${r}.pooler.supabase.com`,
+        port: 6543,
+        user: `postgres.${PROJECT_REF}`,
+        label: `pooler ${poolerPrefix}-${r}`,
+      })
+      if (c) {
+        try { writeFileSync(cacheFile, `${poolerPrefix}:${r}`) } catch { /* non-fatal */ }
+        return c
+      }
+    }
+  }
+  throw new Error('Could not reach Supabase — set SUPABASE_POOLER_REGION and re-run.')
+}
+
+const c = await connect()
+try {
+  // 1) Resolve the target tree.
+  const trees = await c.query(
+    'select id, name, created_by from public.family_trees where name = $1',
+    [treeName],
+  )
+  if (trees.rows.length !== 1) {
+    console.error(`✗ Expected exactly one tree named "${treeName}", found ${trees.rows.length}.`)
+    const all = await c.query('select name from public.family_trees order by created_at')
+    console.error('  Available trees:', all.rows.map((r) => r.name).join(' · '))
+    process.exit(1)
+  }
+  const treeId: string = trees.rows[0].id
+  const ownerId: string = trees.rows[0].created_by
+  const existing = await c.query(
+    'select count(*)::int as n from public.members where tree_id = $1',
+    [treeId],
+  )
+  console.log(`Target tree "${treeName}" (${treeId})`)
+  console.log(`  current members: ${existing.rows[0].n} → will be replaced by ${ADLER_MEMBERS.length} seed members`)
+  console.log(`  owner (created_by for new rows): ${ownerId}`)
+
+  if (dryRun) {
+    console.log('--dry-run: no changes made.')
+    process.exit(0)
+  }
+
+  await c.query('begin')
+
+  // 2) Clear the old population. Relationships cascade from members,
+  //    but delete them explicitly first so cross-tree edges (if any)
+  //    can't dangle.
+  const delRels = await c.query(
+    `delete from public.relationships
+      where member_a_id in (select id from public.members where tree_id = $1)
+         or member_b_id in (select id from public.members where tree_id = $1)`,
+    [treeId],
+  )
+  const delMembers = await c.query(
+    'delete from public.members where tree_id = $1',
+    [treeId],
+  )
+  console.log(`  deleted ${delRels.rowCount} relationships, ${delMembers.rowCount} members`)
+
+  // 3) Insert seed members; map seed ids → fresh DB UUIDs.
+  const idMap = new Map<string, string>()
+  for (const m of ADLER_MEMBERS) {
+    const res = await c.query(
+      `insert into public.members
+         (first_name, last_name, maiden_name, nickname, birth_date, death_date,
+          bio, photo_url, gender, birth_order, lineage, tree_id, created_by)
+       values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+       returning id`,
+      [
+        m.first_name, m.last_name, m.maiden_name ?? null, m.nickname ?? null,
+        m.birth_date ?? null, m.death_date ?? null, m.bio ?? null,
+        m.photo_url ?? null, m.gender ?? null, m.birth_order ?? null,
+        m.lineage ?? null, treeId, ownerId,
+      ],
+    )
+    idMap.set(m.id, res.rows[0].id)
+  }
+  console.log(`  inserted ${idMap.size} members`)
+
+  // 4) Re-link relationships through the id map.
+  let relCount = 0
+  for (const r of ADLER_RELATIONSHIPS) {
+    const a = idMap.get(r.member_a_id)
+    const b = idMap.get(r.member_b_id)
+    if (!a || !b) throw new Error(`Seed relationship references unknown member: ${r.member_a_id} → ${r.member_b_id}`)
+    await c.query(
+      `insert into public.relationships (member_a_id, member_b_id, type, status)
+       values ($1,$2,$3,$4)`,
+      [a, b, r.type, r.status ?? null],
+    )
+    relCount++
+  }
+  console.log(`  inserted ${relCount} relationships`)
+
+  await c.query('commit')
+  console.log('✓ Demo tree reseeded.')
+} catch (e) {
+  try { await c.query('rollback') } catch { /* ignore */ }
+  console.error('✗ Seeding failed (rolled back):', e)
+  process.exitCode = 1
+} finally {
+  await c.end()
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -132,16 +132,21 @@ export default function App() {
     // from now-deleted trees ("טסט יקיר" etc.) — the new engine treats
     // every relationship row as authoritative, so we force-flush so the
     // store rehydrates strictly from what RLS returns.
+    // Demo bucket bumps to v7 with the 10-generation pilot seed — a
+    // returning demo visitor must get the new fixture, so the old demo
+    // snapshots are intentionally NOT migrated (no legacy hydration).
     const STORAGE_KEY = demoMode
-      ? 'ft-state-v5'
+      ? 'ft-state-v7'
       : `ft-state-v6-${session?.user?.id ?? 'anon'}`
-    const LEGACY_KEYS = demoMode
-      ? ['ft-state-v4', 'ft-state-v3', 'ft-demo-state-v2', 'ft-demo-state-v1']
-      : []
+    const LEGACY_KEYS: string[] = []
 
-    // Settings keys from retired features (fake layout modes, density
-    // toggle) — removed unconditionally so stale prefs don't linger.
-    for (const k of ['ft-tree-layout-mode', 'ft-tree-density']) {
+    // Keys from retired features + retired demo snapshots — removed
+    // unconditionally so stale data doesn't linger.
+    for (const k of [
+      'ft-tree-layout-mode', 'ft-tree-density',
+      'ft-state-v5', 'ft-state-v4', 'ft-state-v3',
+      'ft-demo-state-v2', 'ft-demo-state-v1',
+    ]) {
       try { window.localStorage.removeItem(k) } catch { /* ignore */ }
     }
 
@@ -178,6 +183,10 @@ export default function App() {
         notes: (Array.isArray((parsed as { notes?: unknown }).notes)
           ? (parsed as { notes: unknown[] }).notes
           : []) as never[],
+        // Same defensive default for `feedback` (help "?" reports).
+        feedback: (Array.isArray((parsed as { feedback?: unknown }).feedback)
+          ? (parsed as { feedback: unknown[] }).feedback
+          : []) as never[],
       })
       restored = true
     }
@@ -198,6 +207,7 @@ export default function App() {
         // branch and show an empty canvas.
         trees: demoMode ? ADLER_TREES : [],
         notes: [],
+        feedback: [],
       })
       // Auto-select the demo tree as active so /tree renders the
       // seed without forcing the user through a tree-picker first.
@@ -245,6 +255,7 @@ export default function App() {
             relationships: s.relationships,
             trees: s.trees,
             notes: s.notes,
+            feedback: s.feedback,
           }),
         )
         for (const k of LEGACY_KEYS) window.localStorage.removeItem(k)
@@ -270,6 +281,7 @@ export default function App() {
                 relationships: s.relationships,
                 trees: s.trees,
                 notes: s.notes,
+                feedback: s.feedback,
               }),
             )
           } catch { /* still won't fit — give up */ }
@@ -282,7 +294,8 @@ export default function App() {
         state.members === prev.members &&
         state.relationships === prev.relationships &&
         state.trees === prev.trees &&
-        state.notes === prev.notes
+        state.notes === prev.notes &&
+        state.feedback === prev.feedback
       ) return
       write()
     })

--- a/src/components/AddMemberModal.tsx
+++ b/src/components/AddMemberModal.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useFamilyStore } from '../store/useFamilyStore'
 import { useLang } from '../i18n/useT'
+import { useCloseOnBack } from '../hooks/useCloseOnBack'
 import type { Gender, Lineage } from '../types'
 import { linkRelative, type RelativeDirection } from '../lib/relatives'
 
@@ -16,6 +17,8 @@ export default function AddMemberModal({ open, onClose }: Props) {
     members, selectedMemberId, profile, activeTreeId,
   } = useFamilyStore()
   const { t, lang } = useLang()
+  // Phone back button closes the modal instead of leaving the page.
+  useCloseOnBack(open, onClose)
   const [form, setForm] = useState({ first_name: '', last_name: '', maiden_name: '', birth_date: '', death_date: '', bio: '', photo_url: '', gender: '' as Gender | '', birth_order: '', lineage: '' as Lineage | '' })
   const [loading, setLoading] = useState(false)
   const photoInputRef = useRef<HTMLInputElement>(null)

--- a/src/components/EditMemberModal.tsx
+++ b/src/components/EditMemberModal.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useFamilyStore } from '../store/useFamilyStore'
 import { useLang, isRTL } from '../i18n/useT'
+import { useCloseOnBack } from '../hooks/useCloseOnBack'
 import { PersonAvatarIcon } from './MemberNode'
 import { getRingGradient, getFallbackGradient } from './memberVisuals'
 import type { Member, Gender, Lineage } from '../types'
@@ -76,6 +77,8 @@ export default function EditMemberModal({ open, onClose, member }: Props) {
   )
   const { t, lang } = useLang()
   const rtl = isRTL(lang)
+  // Phone back button closes the modal instead of leaving the page.
+  useCloseOnBack(open, onClose)
   const [form, setForm] = useState<FormState>(() => fromMember(member))
   const [saving, setSaving] = useState(false)
   const profileInputRef = useRef<HTMLInputElement>(null)

--- a/src/components/EditModeCoachMark.tsx
+++ b/src/components/EditModeCoachMark.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { useFamilyStore } from '../store/useFamilyStore'
+import { useLang, isRTL } from '../i18n/useT'
+
+/**
+ * One-time explainer for edit mode. The four per-card "+" buttons are
+ * compact by design, which left first-time editors guessing which
+ * relative each one adds (owner request: "make it clear what every
+ * plus does"). This balloon pops every time edit mode turns ON until
+ * the user explicitly confirms with "got it" — after that it never
+ * returns (localStorage flag), keeping repeat editing friction-free.
+ */
+const DISMISS_KEY = 'ft-editmode-coach-dismissed'
+
+function alreadyDismissed(): boolean {
+  try {
+    return window.localStorage.getItem(DISMISS_KEY) === '1'
+  } catch {
+    // Private mode — show it, worst case it repeats.
+    return false
+  }
+}
+
+export default function EditModeCoachMark() {
+  const isEditMode = useFamilyStore((s) => s.isEditMode)
+  const { t, lang } = useLang()
+  const rtl = isRTL(lang)
+  // Visible whenever edit mode turns ON and the user hasn't confirmed
+  // yet. Adjusted during render (same pattern as TreeSearchModal's
+  // open-reset) instead of an effect — react-hooks v7 forbids the
+  // setState-in-effect version.
+  const [visible, setVisible] = useState(() => isEditMode && !alreadyDismissed())
+  const [prevEdit, setPrevEdit] = useState(isEditMode)
+  if (isEditMode !== prevEdit) {
+    setPrevEdit(isEditMode)
+    setVisible(isEditMode && !alreadyDismissed())
+  }
+
+  const dismiss = () => {
+    try { window.localStorage.setItem(DISMISS_KEY, '1') } catch { /* ignore quota */ }
+    setVisible(false)
+  }
+
+  // Direction glyphs are tiny inline SVGs (no emoji per code style).
+  // SVG paths do NOT mirror with dir=rtl, so the side arrows are picked
+  // per language to match the labels: sibling sits at inline-START
+  // (right in Hebrew, left in English), spouse at inline-END.
+  const ARROW_RIGHT = 'M3 7h8M7.5 3.5L11 7l-3.5 3.5'
+  const ARROW_LEFT = 'M11 7H3M6.5 3.5L3 7l3.5 3.5'
+  const rows: { key: string; label: string; arrow: string }[] = [
+    { key: 'parent',  label: t.editCoachParent,  arrow: 'M7 11V3M3.5 6.5L7 3l3.5 3.5' },
+    { key: 'child',   label: t.editCoachChild,   arrow: 'M7 3v8M3.5 7.5L7 11l3.5-3.5' },
+    { key: 'sibling', label: t.editCoachSibling, arrow: rtl ? ARROW_RIGHT : ARROW_LEFT },
+    { key: 'spouse',  label: t.editCoachSpouse,  arrow: rtl ? ARROW_LEFT : ARROW_RIGHT },
+  ]
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        // Flex wrapper instead of translate-centring — framer-motion owns
+        // the card's transform for the entry animation.
+        <div className="fixed inset-x-0 bottom-[128px] z-[70] flex justify-center px-4 pointer-events-none no-print">
+          <motion.div
+            initial={{ opacity: 0, y: 16, scale: 0.96 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 16, scale: 0.96 }}
+            transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
+            className="pointer-events-auto w-full max-w-[340px] rounded-3xl bg-white/95 backdrop-blur-2xl border border-white/60 shadow-glass-lg p-4 space-y-3"
+            role="dialog"
+            aria-label={t.editCoachTitle}
+          >
+            <div className="flex items-center gap-2">
+              <span className="w-8 h-8 rounded-full bg-[#007AFF]/10 flex items-center justify-center flex-shrink-0">
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                  <path d="M7 2v10M2 7h10" stroke="#007AFF" strokeWidth="2" strokeLinecap="round" />
+                </svg>
+              </span>
+              <div>
+                <p className="text-sf-subhead font-bold text-[#1C1C1E]">{t.editCoachTitle}</p>
+                <p className="text-[11px] text-[#8E8E93] leading-snug">{t.editCoachIntro}</p>
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              {rows.map((row) => (
+                <div key={row.key} className="flex items-center gap-2.5 rounded-xl bg-[#F2F2F7] px-3 py-2">
+                  <span className="relative w-6 h-6 rounded-full bg-white ring-1 ring-[#007AFF]/25 text-[#007AFF] flex items-center justify-center flex-shrink-0">
+                    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden>
+                      <path d={row.arrow} stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  </span>
+                  <span className="text-[12px] font-semibold text-[#3C3C43] leading-snug">{row.label}</span>
+                </div>
+              ))}
+            </div>
+            <button
+              type="button"
+              onClick={dismiss}
+              className="w-full py-2.5 rounded-2xl bg-gradient-to-r from-[#007AFF] to-[#32ADE6] text-white text-sf-subhead font-bold active:scale-[0.98] transition"
+            >
+              {t.editCoachGotIt}
+            </button>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/components/QuickAddRelativeModal.tsx
+++ b/src/components/QuickAddRelativeModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useLang, isRTL } from '../i18n/useT'
+import { useCloseOnBack } from '../hooks/useCloseOnBack'
 import { useFamilyStore } from '../store/useFamilyStore'
 import type { Member, Gender } from '../types'
 import { linkRelative, type RelativeDirection } from '../lib/relatives'
@@ -54,6 +55,10 @@ export default function QuickAddRelativeModal({ open, onClose, anchor, direction
     : ''
   const [gender, setGender] = useState<Gender | ''>(defaultGender)
   const [busy, setBusy] = useState(false)
+
+  // Phone back button closes the popover instead of leaving the page.
+  // Must run BEFORE the early return below — hook order is fixed.
+  useCloseOnBack(open && !!anchor, onClose)
 
   if (!open || !anchor) return null
 

--- a/src/components/RelationshipManager.tsx
+++ b/src/components/RelationshipManager.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useFamilyStore } from '../store/useFamilyStore'
 import { useLang, isRTL } from '../i18n/useT'
+import { useCloseOnBack } from '../hooks/useCloseOnBack'
 import { PersonAvatarIcon } from './MemberNode'
 import { getRingGradient, getFallbackGradient } from './memberVisuals'
 import { canManageRelationships } from '../lib/permissions'
@@ -20,6 +21,8 @@ export default function RelationshipManager({ open, onClose, member }: Props) {
     useFamilyStore()
   const { t, lang } = useLang()
   const rtl = isRTL(lang)
+  // Phone back button closes the manager instead of leaving the page.
+  useCloseOnBack(open, onClose)
   const [tab, setTab] = useState<TabKey>('parents')
   const [picker, setPicker] = useState<RelationshipType | null>(null)
   const [pickerKind, setPickerKind] = useState<'parent' | 'spouse' | 'child' | null>(null)

--- a/src/components/TreeSearchModal.tsx
+++ b/src/components/TreeSearchModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useFamilyStore } from '../store/useFamilyStore'
 import { useLang, isRTL } from '../i18n/useT'
+import { useCloseOnBack } from '../hooks/useCloseOnBack'
 import { PersonAvatarIcon } from './MemberNode'
 import { getRingGradient, getFallbackGradient } from './memberVisuals'
 import type { Member } from '../types'
@@ -30,6 +31,8 @@ export default function TreeSearchModal({
   const { members, setSelectedMemberId } = useFamilyStore()
   const { t, lang } = useLang()
   const rtl = isRTL(lang)
+  // Phone back button closes the modal instead of leaving the page.
+  useCloseOnBack(open, onClose)
   const inputRef = useRef<HTMLInputElement>(null)
   const [query, setQuery] = useState('')
 

--- a/src/components/TreeSwitcher.tsx
+++ b/src/components/TreeSwitcher.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useFamilyStore } from '../store/useFamilyStore'
 import { useLang } from '../i18n/useT'
+import { useCloseOnBack } from '../hooks/useCloseOnBack'
 import type { FamilyTree } from '../types/index'
 
 /**
@@ -26,6 +27,10 @@ export default function TreeSwitcher({
   const [deleteTarget, setDeleteTarget] = useState<FamilyTree | null>(null)
   const rootRef = useRef<HTMLDivElement>(null)
   const isAdmin = profile?.role === 'admin'
+
+  // Phone back button closes the popover / confirm dialog in turn.
+  useCloseOnBack(open, () => setOpen(false))
+  useCloseOnBack(deleteTarget !== null, () => setDeleteTarget(null))
 
   useEffect(() => {
     if (!open) return
@@ -97,22 +102,26 @@ export default function TreeSwitcher({
 
       <AnimatePresence>
         {open && (
+          // Viewport-centred via a fixed full-width flex wrapper. The
+          // previous `absolute end-0` anchored the popover's inline-end
+          // edge to the trigger — in RTL that's the LEFT edge, so the
+          // body grew RIGHTWARD and clipped off-screen on phones (owner
+          // bug report, with screenshot). A transform-based `left:50%`
+          // centring can't be used either: framer-motion owns the
+          // element's transform for the scale/y animation. The flex
+          // wrapper centres without transforms and without caring where
+          // the trigger button happens to sit in the top bar.
+          <div
+            className="fixed inset-x-0 z-[60] flex justify-center px-3 pointer-events-none"
+            style={{ top: 'calc(env(safe-area-inset-top, 0px) + 68px)' }}
+          >
           <motion.div
             role="menu"
             initial={{ opacity: 0, y: -6, scale: 0.97 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: -6, scale: 0.97 }}
             transition={{ duration: 0.16, ease: [0.16, 1, 0.3, 1] }}
-            // Button-anchored absolute positioning (matches the pattern
-            // QuickAccessMenu uses). The previous fixed/centred approach
-            // looked off-centre on mobile and could clip off-screen
-            // because `left: 50%` ignores where the button actually is.
-            // Now: popover docks under the trigger via the parent
-            // `relative` wrapper; on RTL it docks against the right
-            // edge so the dropdown opens INWARD toward the canvas
-            // instead of toward the screen edge. max-width keeps it
-            // from overflowing a 360px viewport.
-            className="absolute z-[60] mt-2 end-0 w-[min(280px,calc(100vw-24px))] rounded-2xl bg-white/95 backdrop-blur-2xl border border-white/60 shadow-glass-lg p-2"
+            className="pointer-events-auto w-[min(300px,100%)] rounded-2xl bg-white/95 backdrop-blur-2xl border border-white/60 shadow-glass-lg p-2"
           >
             <p className="px-2 pt-1 pb-2 text-[10px] font-bold uppercase tracking-wider text-[#8E8E93]">
               {t.treeSwitcherTitle}
@@ -157,7 +166,11 @@ export default function TreeSwitcher({
                     type="button"
                     title={t.treeDeleteTree}
                     aria-label={t.treeDeleteTree}
-                    onClick={(e) => { e.stopPropagation(); setDeleteTarget(tt) }}
+                    // Close the popover BEFORE the dialog opens — it sits at
+                    // z-[60] and used to paint OVER the confirmation overlay
+                    // (owner-reported layering bug), leaving the user unable
+                    // to read the prompt they were supposed to answer.
+                    onClick={(e) => { e.stopPropagation(); setOpen(false); setDeleteTarget(tt) }}
                     className="flex-shrink-0 w-7 h-7 rounded-xl flex items-center justify-center text-[#FF3B30]/60 hover:text-[#FF3B30] hover:bg-[#FF3B30]/8 transition"
                   >
                     <svg width="13" height="13" viewBox="0 0 13 13" fill="none">
@@ -217,6 +230,7 @@ export default function TreeSwitcher({
               )}
             </div>
           </motion.div>
+          </div>
         )}
       </AnimatePresence>
 
@@ -227,7 +241,10 @@ export default function TreeSwitcher({
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+            // z-[110]: a confirmation must outrank EVERYTHING it can be
+            // launched from — the switcher popover (z-[60]) and the edit
+            // modal (z-[100]) — or it renders underneath and looks broken.
+            className="fixed inset-0 z-[110] flex items-center justify-center bg-black/40 backdrop-blur-sm"
             onClick={() => setDeleteTarget(null)}
           >
             <motion.div

--- a/src/components/TutorialOverlay.tsx
+++ b/src/components/TutorialOverlay.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useLang, isRTL } from '../i18n/useT'
+import { useCloseOnBack } from '../hooks/useCloseOnBack'
 
 /**
  * Interactive guided-tour overlay.
@@ -67,6 +68,8 @@ const EDGE_PAD = 16
 export default function TutorialOverlay({ open, steps, onClose }: Props) {
   const { lang } = useLang()
   const rtl = isRTL(lang)
+  // Phone back button exits the tour instead of leaving the page.
+  useCloseOnBack(open, onClose)
   const [stepIndex, setStepIndex] = useState(0)
   const [rect, setRect] = useState<TargetRect | null>(null)
   const [captionPos, setCaptionPos] = useState<{ top: number; left: number; width: number } | null>(null)

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -11,7 +11,7 @@ import { getRingGradient, getFallbackGradient } from '../memberVisuals'
 import type { EditRequest, Member, Profile, UserRole, MasterPermissions, AccessRequest } from '../../types'
 import type { PermissionKey } from '../../lib/permissions'
 
-type Tab = 'overview' | 'users' | 'members' | 'requests' | 'access' | 'invites' | 'system'
+type Tab = 'overview' | 'users' | 'members' | 'requests' | 'access' | 'reports' | 'invites' | 'system'
 
 const ROLE_OPTIONS: { key: UserRole; icon: string; labelKey: 'adminRoleGuest' | 'adminRoleUser' | 'adminRoleMaster' | 'adminRoleAdmin' }[] = [
   { key: 'guest',  icon: '👤', labelKey: 'adminRoleGuest' },
@@ -59,6 +59,7 @@ export default function AdminDashboard() {
     editRequests, fetchEditRequests, approveEditRequest, rejectEditRequest,
     members, deleteMember, profile,
     accessRequests, fetchAccessRequests, decideAccessRequest, updateProfileById,
+    feedback, fetchFeedback, updateFeedback, deleteFeedback,
   } = useFamilyStore()
   const { t, lang } = useLang()
   const rtl = isRTL(lang)
@@ -260,8 +261,11 @@ export default function AdminDashboard() {
   // exhaustive-deps honest without changing the run-once behaviour.
   useEffect(() => {
     fetchEditRequests()
-    if (SUPABASE_CONFIGURED) fetchAccessRequests()
-  }, [fetchEditRequests, fetchAccessRequests])
+    if (SUPABASE_CONFIGURED) {
+      fetchAccessRequests()
+      fetchFeedback()
+    }
+  }, [fetchEditRequests, fetchAccessRequests, fetchFeedback])
 
   const pendingAccess = useMemo(
     () => accessRequests.filter(r => r.status === 'pending'),
@@ -485,6 +489,7 @@ where email = '${dbAdminStatus.email ?? '<האימייל-שלך>'}';`}
             ['members', t.adminTabMembers, '🌳'],
             ['requests', t.adminTabRequests, '🔔'],
             ['access', t.adminTabAccess, '🚪'],
+            ['reports', t.adminTabReports, '🐞'],
             ['invites', t.adminTabInvites, '🔑'],
             ['system', t.adminTabSystem, '⚙️'],
           ] as const).map(([key, label, icon]) => (
@@ -733,6 +738,77 @@ where email = '${dbAdminStatus.email ?? '<האימייל-שלך>'}';`}
                       onApprove={(role) => decideAccessRequest(req.id, 'approved', role)}
                       onReject={() => decideAccessRequest(req.id, 'rejected')}
                     />
+                  ))}
+                </div>
+              )}
+            </motion.div>
+          )}
+
+          {tab === 'reports' && (
+            <motion.div
+              key="reports"
+              initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }} transition={{ duration: 0.2 }}
+              className="space-y-3"
+            >
+              <SectionHeader title={t.adminReportsTitle} desc={t.adminReportsDesc} />
+              {feedback.length === 0 ? (
+                <EmptyBlock icon="📭" text={t.adminReportsEmpty} />
+              ) : (
+                <div className="space-y-2">
+                  {feedback.map((f) => (
+                    <div
+                      key={f.id}
+                      className={`glass-strong rounded-3xl p-4 shadow-glass space-y-2 ${
+                        f.status === 'resolved' ? 'opacity-60' : ''
+                      }`}
+                    >
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className={`px-2 py-0.5 rounded-full text-[10.5px] font-bold ${
+                          f.category === 'bug'
+                            ? 'bg-[#FF3B30]/12 text-[#FF3B30]'
+                            : 'bg-[#5E5CE6]/12 text-[#5E5CE6]'
+                        }`}>
+                          {f.category === 'bug' ? t.feedbackCategoryBug : t.feedbackCategoryQuestion}
+                        </span>
+                        <span className="text-[11.5px] font-semibold text-[#1C1C1E]">{f.author_name}</span>
+                        <span className="text-[10.5px] text-[#8E8E93]" dir="ltr">
+                          {new Date(f.created_at).toLocaleDateString(lang === 'he' ? 'he-IL' : 'en-US', {
+                            day: 'numeric', month: 'short', year: 'numeric',
+                          })}
+                        </span>
+                        {f.status === 'resolved' && (
+                          <span className="px-2 py-0.5 rounded-full text-[10.5px] font-bold bg-[#34C759]/12 text-[#34C759]">
+                            {t.feedbackStatusResolved}
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-[13px] text-[#3C3C43] leading-relaxed whitespace-pre-line">{f.body}</p>
+                      <div className="flex items-center gap-2 pt-1">
+                        <button
+                          type="button"
+                          onClick={() => updateFeedback(f.id, {
+                            status: f.status === 'resolved' ? 'open' : 'resolved',
+                          })}
+                          className={`px-3 py-1.5 rounded-xl text-[11.5px] font-bold transition ${
+                            f.status === 'resolved'
+                              ? 'bg-[#F2F2F7] text-[#636366]'
+                              : 'bg-[#34C759] text-white'
+                          }`}
+                        >
+                          {f.status === 'resolved' ? t.feedbackReopen : t.feedbackMarkResolved}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            if (window.confirm(t.feedbackDeleteConfirm)) deleteFeedback(f.id)
+                          }}
+                          className="px-3 py-1.5 rounded-xl text-[11.5px] font-bold text-[#FF3B30] hover:bg-[#FF3B30]/8 transition"
+                        >
+                          {t.feedbackDelete}
+                        </button>
+                      </div>
+                    </div>
                   ))}
                 </div>
               )}

--- a/src/components/help/FaqModal.tsx
+++ b/src/components/help/FaqModal.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { useLang, isRTL, type Translations } from '../../i18n/useT'
+import { useCloseOnBack } from '../../hooks/useCloseOnBack'
+
+/**
+ * Built-in FAQ — short canned answers reachable from the help "?"
+ * menu. Content lives entirely in translations.ts (the faqQ / faqA
+ * key pairs) so both languages stay in lockstep; this component is
+ * just an accordion shell.
+ */
+const FAQ_KEYS: { q: keyof Translations; a: keyof Translations }[] = [
+  { q: 'faqQ1', a: 'faqA1' },
+  { q: 'faqQ2', a: 'faqA2' },
+  { q: 'faqQ3', a: 'faqA3' },
+  { q: 'faqQ4', a: 'faqA4' },
+  { q: 'faqQ5', a: 'faqA5' },
+  { q: 'faqQ6', a: 'faqA6' },
+  { q: 'faqQ7', a: 'faqA7' },
+  { q: 'faqQ8', a: 'faqA8' },
+]
+
+export default function FaqModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const { t, lang } = useLang()
+  const rtl = isRTL(lang)
+  const [openIdx, setOpenIdx] = useState<number | null>(0)
+
+  // Phone back button closes the FAQ instead of leaving the page.
+  useCloseOnBack(open, onClose)
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          dir={rtl ? 'rtl' : 'ltr'}
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/40 backdrop-blur-sm p-4"
+          onClick={onClose}
+        >
+          <motion.div
+            initial={{ opacity: 0, scale: 0.94, y: 12 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.94, y: 12 }}
+            transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
+            onClick={(e) => e.stopPropagation()}
+            className="w-full max-w-sm max-h-[min(620px,calc(100vh-48px))] flex flex-col rounded-3xl bg-white shadow-glass-lg overflow-hidden"
+          >
+            <header className="flex items-center justify-between px-5 pt-4 pb-3 border-b border-black/5">
+              <h2 className="text-sf-headline font-bold text-[#1C1C1E]">{t.faqTitle}</h2>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label={t.faqClose}
+                className="w-8 h-8 rounded-full bg-[#F2F2F7] flex items-center justify-center text-[#636366] active:scale-95 transition"
+              >
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                  <path d="M2 2L10 10M10 2L2 10" stroke="#636366" strokeWidth="1.5" strokeLinecap="round" />
+                </svg>
+              </button>
+            </header>
+            <div className="flex-1 overflow-y-auto p-3 space-y-1.5">
+              {FAQ_KEYS.map(({ q, a }, i) => {
+                const expanded = openIdx === i
+                return (
+                  <div key={q} className="rounded-2xl bg-[#F2F2F7] overflow-hidden">
+                    <button
+                      type="button"
+                      onClick={() => setOpenIdx(expanded ? null : i)}
+                      aria-expanded={expanded}
+                      className="w-full flex items-center justify-between gap-2 px-3.5 py-2.5 text-start"
+                    >
+                      <span className="text-[13px] font-semibold text-[#1C1C1E] leading-snug">{t[q]}</span>
+                      <motion.svg
+                        width="12" height="12" viewBox="0 0 12 12" fill="none"
+                        animate={{ rotate: expanded ? 180 : 0 }}
+                        transition={{ duration: 0.16 }}
+                        className="flex-shrink-0"
+                        aria-hidden
+                      >
+                        <path d="M2.5 4.5L6 8l3.5-3.5" stroke="#8E8E93" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+                      </motion.svg>
+                    </button>
+                    <AnimatePresence initial={false}>
+                      {expanded && (
+                        <motion.div
+                          initial={{ height: 0, opacity: 0 }}
+                          animate={{ height: 'auto', opacity: 1 }}
+                          exit={{ height: 0, opacity: 0 }}
+                          transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
+                        >
+                          <p className="px-3.5 pb-3 text-[12px] text-[#3C3C43] leading-relaxed whitespace-pre-line">
+                            {t[a]}
+                          </p>
+                        </motion.div>
+                      )}
+                    </AnimatePresence>
+                  </div>
+                )
+              })}
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/components/help/FeedbackModal.tsx
+++ b/src/components/help/FeedbackModal.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { useLang, isRTL } from '../../i18n/useT'
+import { useFamilyStore } from '../../store/useFamilyStore'
+import { useCloseOnBack } from '../../hooks/useCloseOnBack'
+import type { FeedbackCategory } from '../../types'
+
+/**
+ * "Report to the admin" form, reachable from the help "?" menu. Saves
+ * through the optimistic feedback store action, so it works in demo
+ * mode too; in production the row lands in the `feedback` table and
+ * surfaces in the admin dashboard's "reports" tab.
+ */
+export default function FeedbackModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const { t, lang } = useLang()
+  const rtl = isRTL(lang)
+  const { profile, addFeedback } = useFamilyStore()
+  const [category, setCategory] = useState<FeedbackCategory>('bug')
+  const [body, setBody] = useState('')
+  const [sent, setSent] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  // Phone back button closes the form instead of leaving the page.
+  useCloseOnBack(open, onClose)
+
+  const handleClose = () => {
+    onClose()
+    // Reset AFTER the exit animation would have hidden the content.
+    window.setTimeout(() => { setSent(false); setBody(''); setCategory('bug') }, 250)
+  }
+
+  const submit = async () => {
+    if (!body.trim() || busy) return
+    setBusy(true)
+    try {
+      await addFeedback({
+        author_id: profile?.id ?? 'anonymous',
+        author_name: profile?.full_name ?? 'אנונימי',
+        category,
+        body: body.trim(),
+        context: window.location.hash || null,
+      })
+      setSent(true)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          dir={rtl ? 'rtl' : 'ltr'}
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/40 backdrop-blur-sm p-4"
+          onClick={handleClose}
+        >
+          <motion.div
+            initial={{ opacity: 0, scale: 0.94, y: 12 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.94, y: 12 }}
+            transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
+            onClick={(e) => e.stopPropagation()}
+            className="w-full max-w-sm rounded-3xl bg-white shadow-glass-lg p-5 space-y-4"
+          >
+            {sent ? (
+              <div className="flex flex-col items-center text-center gap-3 py-4">
+                <span className="w-14 h-14 rounded-full bg-[#34C759]/12 flex items-center justify-center">
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+                    <path d="M5 12.5l4.5 4.5L19 7.5" stroke="#34C759" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </span>
+                <div>
+                  <p className="text-sf-headline font-bold text-[#1C1C1E]">{t.feedbackSent}</p>
+                  <p className="text-[12px] text-[#8E8E93] mt-1 leading-relaxed">{t.feedbackSentDesc}</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  className="mt-1 w-full py-2.5 rounded-2xl bg-[#F2F2F7] text-[#1C1C1E] text-sf-subhead font-semibold"
+                >
+                  {t.faqClose}
+                </button>
+              </div>
+            ) : (
+              <>
+                <header className="flex items-center justify-between">
+                  <h2 className="text-sf-headline font-bold text-[#1C1C1E]">{t.feedbackTitle}</h2>
+                  <button
+                    type="button"
+                    onClick={handleClose}
+                    aria-label={t.faqClose}
+                    className="w-8 h-8 rounded-full bg-[#F2F2F7] flex items-center justify-center text-[#636366] active:scale-95 transition"
+                  >
+                    <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                      <path d="M2 2L10 10M10 2L2 10" stroke="#636366" strokeWidth="1.5" strokeLinecap="round" />
+                    </svg>
+                  </button>
+                </header>
+                <p className="text-[12px] text-[#8E8E93] -mt-2 leading-relaxed">{t.feedbackDesc}</p>
+
+                <div className="bg-[#F2F2F7] rounded-xl p-1 flex gap-1">
+                  {([
+                    ['bug', t.feedbackCategoryBug],
+                    ['question', t.feedbackCategoryQuestion],
+                  ] as const).map(([key, label]) => (
+                    <button
+                      key={key}
+                      type="button"
+                      onClick={() => setCategory(key)}
+                      className={`flex-1 py-1.5 rounded-lg text-[12px] font-semibold transition ${
+                        category === key ? 'bg-white text-[#1C1C1E] shadow-sm' : 'text-[#636366]'
+                      }`}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+
+                <textarea
+                  autoFocus
+                  value={body}
+                  onChange={(e) => setBody(e.target.value)}
+                  placeholder={category === 'bug' ? t.feedbackPlaceholderBug : t.feedbackPlaceholderQuestion}
+                  rows={5}
+                  className="w-full rounded-2xl bg-[#F2F2F7] px-3.5 py-3 text-[13px] text-[#1C1C1E] placeholder:text-[#8E8E93] outline-none focus:ring-2 focus:ring-[#007AFF]/40 resize-none"
+                />
+
+                <button
+                  type="button"
+                  onClick={submit}
+                  disabled={!body.trim() || busy}
+                  className="w-full py-2.5 rounded-2xl bg-gradient-to-r from-[#007AFF] to-[#32ADE6] text-white text-sf-subhead font-bold disabled:opacity-40 active:scale-[0.98] transition"
+                >
+                  {busy ? '…' : t.feedbackSend}
+                </button>
+              </>
+            )}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/components/help/HelpMenu.tsx
+++ b/src/components/help/HelpMenu.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useRef, useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { useLang, isRTL } from '../../i18n/useT'
+import { useCloseOnBack } from '../../hooks/useCloseOnBack'
+import Tooltip from '../Tooltip'
+import FaqModal from './FaqModal'
+import FeedbackModal from './FeedbackModal'
+
+/**
+ * The "?" chip at the bottom of the tree-page floating-controls stack.
+ * Used to replay the tutorial directly; the owner asked for a proper
+ * help hub instead, so it now opens a 3-option popover:
+ *   1. guided tour (the existing TutorialOverlay, restarted on demand)
+ *   2. FAQ — short built-in answers
+ *   3. report a bug / ask the admin a question (lands in the admin
+ *      dashboard's "reports" tab)
+ *
+ * Rendered ABSOLUTE inside the same container as the filter chip so the
+ * stack spacing is uniform: filter 144 → focus 196 → help 248. The old
+ * `fixed top:300px` version measured against the viewport instead of
+ * the canvas and floated visibly detached from the chips above it.
+ */
+export default function HelpMenu({ onStartTour }: { onStartTour: () => void }) {
+  const { t, lang } = useLang()
+  const rtl = isRTL(lang)
+  const [open, setOpen] = useState(false)
+  const [faqOpen, setFaqOpen] = useState(false)
+  const [feedbackOpen, setFeedbackOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  // Phone back button closes the popover instead of leaving the page.
+  useCloseOnBack(open, () => setOpen(false))
+
+  useEffect(() => {
+    if (!open) return
+    const onClick = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setOpen(false)
+    document.addEventListener('mousedown', onClick)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onClick)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  const items: { key: string; label: string; desc: string; icon: React.ReactNode; onClick: () => void }[] = [
+    {
+      key: 'tour',
+      label: t.helpTour,
+      desc: t.helpTourDesc,
+      icon: (
+        <svg width="15" height="15" viewBox="0 0 15 15" fill="none">
+          <circle cx="7.5" cy="7.5" r="5.8" stroke="currentColor" strokeWidth="1.4" />
+          <path d="M7.5 4.6v3l2 1.4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      ),
+      onClick: () => { setOpen(false); onStartTour() },
+    },
+    {
+      key: 'faq',
+      label: t.helpFaq,
+      desc: t.helpFaqDesc,
+      icon: (
+        <svg width="15" height="15" viewBox="0 0 15 15" fill="none">
+          <path d="M5.2 5.4a2.3 2.3 0 1 1 3.2 2.1c-.7.3-.9.7-.9 1.4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" />
+          <circle cx="7.5" cy="11.2" r="0.9" fill="currentColor" />
+        </svg>
+      ),
+      onClick: () => { setOpen(false); setFaqOpen(true) },
+    },
+    {
+      key: 'report',
+      label: t.helpReport,
+      desc: t.helpReportDesc,
+      icon: (
+        <svg width="15" height="15" viewBox="0 0 15 15" fill="none">
+          <path d="M2.2 3.5h10.6v7H8l-3 2.5v-2.5H2.2v-7z" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      ),
+      onClick: () => { setOpen(false); setFeedbackOpen(true) },
+    },
+  ]
+
+  return (
+    <div
+      ref={rootRef}
+      // z jumps above the bottom navigation island (z-50) while ANY of
+      // the help surfaces is open. The container's z-index creates the
+      // stacking context for the popover AND the fixed modals inside,
+      // so at the resting z-20 they would all paint UNDER the nav on
+      // short phone viewports.
+      className={`absolute top-[248px] no-print ${open || faqOpen || feedbackOpen ? 'z-[60]' : 'z-20'}`}
+      style={{ [rtl ? 'left' : 'right']: 12 } as React.CSSProperties}
+      data-tour="tree-help"
+    >
+      <div className="relative flex justify-end">
+        <Tooltip content={t.helpMenuTooltip} placement="bottom" align="end">
+          <motion.button
+            type="button"
+            whileTap={{ scale: 0.94 }}
+            onClick={() => setOpen((v) => !v)}
+            aria-label={t.helpMenuTooltip}
+            aria-haspopup="menu"
+            aria-expanded={open}
+            className={`w-9 h-9 rounded-full shadow-glass flex items-center justify-center border transition ${
+              open
+                ? 'bg-[#007AFF] text-white border-transparent'
+                : 'bg-white/95 text-[#007AFF] border-white/70 hover:bg-white'
+            }`}
+          >
+            <span className="text-base font-bold" aria-hidden>?</span>
+          </motion.button>
+        </Tooltip>
+
+        <AnimatePresence>
+          {open && (
+            <motion.div
+              role="menu"
+              initial={{ opacity: 0, y: -6, scale: 0.97 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: -6, scale: 0.97 }}
+              transition={{ duration: 0.16, ease: [0.16, 1, 0.3, 1] }}
+              className="absolute top-full mt-2 w-[230px] rounded-2xl bg-white/95 backdrop-blur-2xl border border-white/60 shadow-glass-lg p-1.5"
+              style={{ [rtl ? 'left' : 'right']: 0 } as React.CSSProperties}
+            >
+              <p className="px-2.5 pt-1.5 pb-1 text-[10px] font-bold uppercase tracking-wider text-[#8E8E93]">
+                {t.helpMenuTitle}
+              </p>
+              {items.map((item) => (
+                <button
+                  key={item.key}
+                  type="button"
+                  role="menuitem"
+                  onClick={item.onClick}
+                  className="w-full flex items-start gap-2.5 px-2.5 py-2 rounded-xl text-start hover:bg-[#F2F2F7] transition"
+                >
+                  <span className="mt-0.5 w-7 h-7 rounded-xl bg-[#007AFF]/10 text-[#007AFF] flex items-center justify-center flex-shrink-0">
+                    {item.icon}
+                  </span>
+                  <span className="flex-1 min-w-0">
+                    <span className="block text-[12.5px] font-semibold text-[#1C1C1E]">{item.label}</span>
+                    <span className="block text-[10.5px] text-[#8E8E93] mt-0.5 leading-snug">{item.desc}</span>
+                  </span>
+                </button>
+              ))}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+
+      <FaqModal open={faqOpen} onClose={() => setFaqOpen(false)} />
+      <FeedbackModal open={feedbackOpen} onClose={() => setFeedbackOpen(false)} />
+    </div>
+  )
+}

--- a/src/components/views/AdvancedFilter.tsx
+++ b/src/components/views/AdvancedFilter.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { useLang, isRTL } from '../../i18n/useT'
+import { useCloseOnBack } from '../../hooks/useCloseOnBack'
 import { useFamilyStore } from '../../store/useFamilyStore'
 import type { Member, Relationship } from '../../types'
 import { findFamilyPath } from './findFamilyPath'
@@ -37,6 +38,8 @@ export default function AdvancedFilter({
     const value = typeof next === 'function' ? next(open) : next
     setOpenTreePopover(value ? 'filter' : null)
   }
+  // Phone back button closes the filter popover instead of leaving.
+  useCloseOnBack(open, () => setOpenTreePopover(null))
   const active = !isDefaultFilter(filters)
   const focusedMember = filters.focusMemberId
     ? members.find(m => m.id === filters.focusMemberId)

--- a/src/components/views/TreeView.tsx
+++ b/src/components/views/TreeView.tsx
@@ -11,6 +11,7 @@ import FocusedCentricView from './FocusedCentricView'
 import TreeMiniMap from './TreeMiniMap'
 import Tooltip from '../Tooltip'
 import { useTreeLayout } from './tree/useTreeLayout'
+import { useCloseOnBack } from '../../hooks/useCloseOnBack'
 import { useViewport } from './tree/useViewport'
 import ConnectorsLayer from './tree/ConnectorsLayer'
 import IssuesBanner from './tree/IssuesBanner'
@@ -29,9 +30,12 @@ import ExportMenu from './tree/ExportMenu'
 export default function TreeView({
   filters,
   onMatchedCount,
+  onAddFirst,
 }: {
   filters: FilterState
   onMatchedCount?: (n: number) => void
+  /** Opens the add-member flow from the empty-state CTA. */
+  onAddFirst?: () => void
 }) {
   const {
     members: allMembers, relationships,
@@ -82,6 +86,11 @@ export default function TreeView({
       : members
     return pool.slice(0, 10)
   }, [members, pickerQuery])
+  // Phone back button: close the focus picker, or exit focused mode,
+  // instead of navigating off the tree.
+  useCloseOnBack(showFocusPicker, () => setOpenTreePopover(null))
+  useCloseOnBack(isFocusedMode, () => setIsFocusedMode(false))
+
   const enterFocusMode = (id: string) => {
     setActiveFocusId(id)
     setIsFocusedMode(true)
@@ -123,7 +132,7 @@ export default function TreeView({
     return () => ro.disconnect()
   }, [])
 
-  if (members.length === 0) return <EmptyState t={t} treeName={activeTree?.name ?? null} />
+  if (members.length === 0) return <EmptyState t={t} treeName={activeTree?.name ?? null} onAdd={onAddFirst} />
 
   return (
     <div
@@ -394,7 +403,11 @@ export default function TreeView({
   )
 }
 
-function EmptyState({ t, treeName }: { t: Translations; treeName: string | null }) {
+function EmptyState({ t, treeName, onAdd }: {
+  t: Translations
+  treeName: string | null
+  onAdd?: () => void
+}) {
   const title = treeName
     ? t.treeEmptyTitleWithName.replace('{name}', treeName)
     : t.treeEmptyTitle
@@ -413,6 +426,26 @@ function EmptyState({ t, treeName }: { t: Translations; treeName: string | null 
         <h3 className="text-sf-title3 text-[#1C1C1E] mb-1">{title}</h3>
         <p className="text-sf-subhead text-[#8E8E93]">{t.treeEmptyDesc}</p>
       </div>
+      {/* Big central "+" — the empty tree used to offer no obvious way
+          to start; the only entry point was the small + in the top bar,
+          which first-time users missed (owner request: "make starting a
+          new tree easy"). */}
+      {onAdd && (
+        <motion.button
+          type="button"
+          onClick={onAdd}
+          whileTap={{ scale: 0.93 }}
+          aria-label={t.treeEmptyAddFirst}
+          className="mt-2 flex flex-col items-center gap-2 group"
+        >
+          <span className="w-16 h-16 rounded-full bg-gradient-to-br from-[#007AFF] to-[#32ADE6] shadow-lg flex items-center justify-center group-hover:scale-105 transition">
+            <svg width="26" height="26" viewBox="0 0 26 26" fill="none">
+              <path d="M13 4v18M4 13h18" stroke="white" strokeWidth="3" strokeLinecap="round" />
+            </svg>
+          </span>
+          <span className="text-sf-subhead font-semibold text-[#007AFF]">{t.treeEmptyAddFirst}</span>
+        </motion.button>
+      )}
     </motion.div>
   )
 }

--- a/src/data/adlerFamily.ts
+++ b/src/data/adlerFamily.ts
@@ -1,39 +1,139 @@
 import type { Member, Relationship, FamilyTree } from '../types'
 
 // ─────────────────────────────────────────────
-// Generic family seed — 1 tree, 7 members, 3 generations
+// Demo family seed — 1 tree, 30 members, 10 generations
 // ─────────────────────────────────────────────
-// Symmetric, deterministic test population for the new layout engine:
-//   • Gen 0: Grandfather + Grandmother
-//   • Gen 1: Father + Mother
-//   • Gen 2: Son #1 + Daughter (centre) + Son #2  (odd-count children
-//           so the middle child sits directly under the parent line)
-// birth_order on the children pins their visual order (left → right
-// in RTL: oldest-son, middle-daughter, youngest-son).
+// Deterministic pilot dataset exercising every profile feature at once
+// (owner request: "fill the demo with fake names, dates and pictures so
+// we can test populated profiles, at least 10 generations deep"):
+//   • 10 generations (born 1742 → 2016) along one main line, with
+//     sibling branches at generations 3, 5, 7 and 8.
+//   • Deceased members across generations 0-6 (+ one in gen 7) so the
+//     deceased filter and the † badge have real data.
+//   • One divorce: דוד ↔ יעל ('ex'), including a shared child (שי) so
+//     the divorced-parents secondary connector renders.
+//   • In-law parents (עמוס + צפורה) above spouse מיכל — exercises the
+//     menorah satellite layout.
+//   • Explicit kohen lineage down the male main line + one levi in-law
+//     so the lineage filter returns a meaningful subset.
+//   • Illustrated DiceBear avatars (clearly not real people) on most
+//     members; a few left photo-less to keep the fallback covered.
+//
+// The same dataset is pushed into the LIVE demo tree by
+// scripts/seed-demo-tree.ts — keep both in sync by editing ONLY here.
 
 const DEMO_TREE_ID = 'demo-family'
+
+// Illustrated avatar URL — DiceBear renders a deterministic cartoon per
+// seed, so the same person always gets the same face. SVG endpoint is
+// free, unauthenticated and license-safe for non-real-person avatars.
+function avatar(seed: string): string {
+  return `https://api.dicebear.com/9.x/adventurer/svg?seed=${seed}&backgroundColor=b6e3f4,c0aede,d1d4f9,ffd5dc,ffdfbf`
+}
 
 export const ADLER_TREES: FamilyTree[] = [
   {
     id: DEMO_TREE_ID,
     name: 'משפחה לדוגמה',
-    description: '3 דורות — בסיס לעיצוב סימטרי',
+    description: '10 דורות — נתוני הדגמה מלאים',
     color: '#007AFF',
     created_by: 'demo',
   },
 ]
 
+// Shorthand: build a member with the demo defaults applied.
+function m(member: Omit<Member, 'tree_id' | 'created_by'>): Member {
+  return { ...member, tree_id: DEMO_TREE_ID, created_by: 'demo' }
+}
+
 export const ADLER_MEMBERS: Member[] = [
-  // Gen 0 — Grandparents
-  { id: 'g01', first_name: 'סבא',   last_name: 'דוגמה', gender: 'male',   birth_date: '1940-01-01', tree_id: DEMO_TREE_ID, created_by: 'demo' },
-  { id: 'g02', first_name: 'סבתא',  last_name: 'דוגמה', gender: 'female', birth_date: '1942-01-01', tree_id: DEMO_TREE_ID, created_by: 'demo' },
-  // Gen 1 — Parents
-  { id: 'p01', first_name: 'אבא',   last_name: 'דוגמה', gender: 'male',   birth_date: '1968-01-01', tree_id: DEMO_TREE_ID, created_by: 'demo' },
-  { id: 'p02', first_name: 'אמא',   last_name: 'דוגמה', gender: 'female', birth_date: '1970-01-01', tree_id: DEMO_TREE_ID, created_by: 'demo' },
-  // Gen 2 — 3 children (birth_order = left→right visual order)
-  { id: 'c01', first_name: 'בן א\'', last_name: 'דוגמה', gender: 'male',   birth_date: '1992-01-01', birth_order: 1, tree_id: DEMO_TREE_ID, created_by: 'demo' },
-  { id: 'c02', first_name: 'בת',    last_name: 'דוגמה', gender: 'female', birth_date: '1995-01-01', birth_order: 2, tree_id: DEMO_TREE_ID, created_by: 'demo' },
-  { id: 'c03', first_name: 'בן ב\'', last_name: 'דוגמה', gender: 'male',   birth_date: '1998-01-01', birth_order: 3, tree_id: DEMO_TREE_ID, created_by: 'demo' },
+  // ── Gen 0 (b. ~1742) ────────────────────────────────────────────
+  m({ id: 'g0m', first_name: 'אליעזר', last_name: 'כרמל', gender: 'male', lineage: 'kohen',
+      birth_date: '1742-03-15', death_date: '1818-06-02', photo_url: avatar('g0m-eliezer'),
+      bio: 'אבי השושלת. סוחר בדים שהקים את בית המשפחה הראשון.' }),
+  m({ id: 'g0f', first_name: 'מרים', last_name: 'כרמל', maiden_name: 'גלבוע', gender: 'female',
+      birth_date: '1748-07-21', death_date: '1825-01-10', photo_url: avatar('g0f-miriam') }),
+
+  // ── Gen 1 (b. ~1771) ────────────────────────────────────────────
+  m({ id: 'g1m', first_name: 'יחיאל', last_name: 'כרמל', gender: 'male', lineage: 'kohen',
+      birth_date: '1771-05-09', death_date: '1840-11-23', photo_url: avatar('g1m-yechiel') }),
+  m({ id: 'g1f', first_name: 'פרומה', last_name: 'כרמל', maiden_name: 'תבור', gender: 'female',
+      birth_date: '1776-09-30', death_date: '1851-04-17', photo_url: avatar('g1f-fruma') }),
+
+  // ── Gen 2 (b. ~1800) ────────────────────────────────────────────
+  m({ id: 'g2m', first_name: 'זלמן', last_name: 'כרמל', gender: 'male', lineage: 'kohen',
+      birth_date: '1800-12-03', death_date: '1872-02-25', photo_url: avatar('g2m-zalman') }),
+  m({ id: 'g2f', first_name: 'רבקה', last_name: 'כרמל', maiden_name: 'שקד', gender: 'female',
+      birth_date: '1806-04-14', death_date: '1881-08-08', photo_url: avatar('g2f-rivka') }),
+
+  // ── Gen 3 (b. ~1831) — first sibling branch ─────────────────────
+  m({ id: 'g3m', first_name: 'מנחם', last_name: 'כרמל', gender: 'male', lineage: 'kohen',
+      birth_date: '1831-01-19', death_date: '1900-03-30', birth_order: 1, photo_url: avatar('g3m-menachem'),
+      bio: 'חזן הקהילה במשך ארבעים שנה.' }),
+  m({ id: 'g3s1', first_name: 'גיטל', last_name: 'כרמל', gender: 'female',
+      birth_date: '1834-08-27', death_date: '1903-05-02', birth_order: 2 }),
+  m({ id: 'g3f', first_name: 'חנה', last_name: 'כרמל', maiden_name: 'ארבל', gender: 'female',
+      birth_date: '1836-06-06', death_date: '1912-10-12', photo_url: avatar('g3f-chana') }),
+
+  // ── Gen 4 (b. ~1862) ────────────────────────────────────────────
+  m({ id: 'g4m', first_name: 'שמואל', last_name: 'כרמל', gender: 'male', lineage: 'kohen',
+      birth_date: '1862-02-11', death_date: '1935-07-19', photo_url: avatar('g4m-shmuel') }),
+  m({ id: 'g4f', first_name: 'לאה', last_name: 'כרמל', maiden_name: 'גולן', gender: 'female',
+      birth_date: '1867-11-28', death_date: '1948-01-05', photo_url: avatar('g4f-lea') }),
+
+  // ── Gen 5 (b. ~1893) — second sibling branch ────────────────────
+  m({ id: 'g5m', first_name: 'אברהם', last_name: 'כרמל', gender: 'male', lineage: 'kohen',
+      birth_date: '1893-04-02', death_date: '1971-09-14', birth_order: 1, photo_url: avatar('g5m-avraham'),
+      bio: 'עלה ארצה ב-1920 והקים משק חקלאי בעמק.' }),
+  m({ id: 'g5s1', first_name: 'פנחס', last_name: 'כרמל', gender: 'male', lineage: 'kohen',
+      birth_date: '1896-10-23', death_date: '1966-03-09', birth_order: 2 }),
+  m({ id: 'g5f', first_name: 'שרה', last_name: 'כרמל', maiden_name: 'אשכול', gender: 'female',
+      birth_date: '1898-08-16', death_date: '1985-12-01', photo_url: avatar('g5f-sara') }),
+
+  // ── Gen 6 (b. ~1925) ────────────────────────────────────────────
+  m({ id: 'g6m', first_name: 'יוסף', last_name: 'כרמל', gender: 'male', lineage: 'kohen',
+      birth_date: '1925-06-18', death_date: '2001-02-07', photo_url: avatar('g6m-yosef'),
+      bio: 'מורה ומחנך. אהב לספר לנכדים על ילדותו בעמק.' }),
+  m({ id: 'g6f', first_name: 'רחל', last_name: 'כרמל', maiden_name: 'אלון', gender: 'female',
+      birth_date: '1929-03-25', death_date: '2010-09-19', photo_url: avatar('g6f-rachel') }),
+
+  // ── Gen 7 (b. ~1950s) — divorce lives here ──────────────────────
+  m({ id: 'g7s1', first_name: 'אסתר', last_name: 'כרמל', gender: 'female',
+      birth_date: '1950-01-30', birth_order: 1, photo_url: avatar('g7s1-esther') }),
+  m({ id: 'g7m', first_name: 'דוד', last_name: 'כרמל', gender: 'male', lineage: 'kohen',
+      birth_date: '1953-07-12', birth_order: 2, photo_url: avatar('g7m-david'),
+      bio: 'מהנדס בגמלאות. חובב צילום וטיולים.' }),
+  m({ id: 'g7s2', first_name: 'משה', last_name: 'כרמל', gender: 'male', lineage: 'kohen',
+      birth_date: '1957-12-05', death_date: '2020-04-22', birth_order: 3, photo_url: avatar('g7s2-moshe') }),
+  // Ex-wife — kept her own surname after the divorce.
+  m({ id: 'g7x', first_name: 'יעל', last_name: 'ירדן', gender: 'female',
+      birth_date: '1955-02-17', photo_url: avatar('g7x-yael') }),
+  m({ id: 'g7f', first_name: 'נעמי', last_name: 'כרמל', maiden_name: 'סביון', gender: 'female',
+      birth_date: '1958-10-08', photo_url: avatar('g7f-naomi') }),
+
+  // ── Gen 8 (b. ~1980s) — in-law parents live here ────────────────
+  m({ id: 'g8s1', first_name: 'שי', last_name: 'כרמל', gender: 'male', lineage: 'kohen',
+      birth_date: '1976-06-25', birth_order: 1, photo_url: avatar('g8s1-shai'),
+      bio: 'בנם של דוד ויעל. גר בחו"ל.' }),
+  m({ id: 'g8m', first_name: 'איתן', last_name: 'כרמל', gender: 'male', lineage: 'kohen',
+      birth_date: '1980-03-03', birth_order: 2, photo_url: avatar('g8m-eitan') }),
+  m({ id: 'g8s2', first_name: 'רות', last_name: 'כרמל', gender: 'female',
+      birth_date: '1983-09-11', birth_order: 3, photo_url: avatar('g8s2-ruth') }),
+  m({ id: 'g8f', first_name: 'מיכל', last_name: 'כרמל', maiden_name: 'דקל', gender: 'female',
+      birth_date: '1982-05-29', photo_url: avatar('g8f-michal') }),
+  // מיכל's parents — render as a menorah satellite above her.
+  m({ id: 'g8il1', first_name: 'עמוס', last_name: 'דקל', gender: 'male', lineage: 'levi',
+      birth_date: '1951-04-09', photo_url: avatar('g8il1-amos') }),
+  m({ id: 'g8il2', first_name: 'צפורה', last_name: 'דקל', maiden_name: 'אשל', gender: 'female',
+      birth_date: '1956-08-14' }),
+
+  // ── Gen 9 (b. 2008-2016) ────────────────────────────────────────
+  m({ id: 'g9c1', first_name: 'נועה', last_name: 'כרמל', gender: 'female',
+      birth_date: '2008-02-14', birth_order: 1, photo_url: avatar('g9c1-noa') }),
+  m({ id: 'g9c2', first_name: 'אורי', last_name: 'כרמל', gender: 'male', lineage: 'kohen',
+      birth_date: '2011-07-07', birth_order: 2, photo_url: avatar('g9c2-uri') }),
+  m({ id: 'g9c3', first_name: 'תמר', last_name: 'כרמל', gender: 'female',
+      birth_date: '2016-11-20', birth_order: 3, photo_url: avatar('g9c3-tamar') }),
 ]
 
 // ─────────────────────────────────────────────
@@ -52,16 +152,46 @@ function rel(
   return r
 }
 
+// Both parents → child, in one call per child.
+function child(of: [string, string], id: string): Relationship[] {
+  return [rel(of[0], id), rel(of[1], id)]
+}
+
 export const ADLER_RELATIONSHIPS: Relationship[] = [
-  // Gen 0 marriage
-  rel('g01', 'g02', 'spouse', 'current'),
-  // Grandparents → father
-  rel('g01', 'p01'),
-  rel('g02', 'p01'),
-  // Gen 1 marriage
-  rel('p01', 'p02', 'spouse', 'current'),
-  // Parents → 3 children
-  rel('p01', 'c01'), rel('p02', 'c01'),
-  rel('p01', 'c02'), rel('p02', 'c02'),
-  rel('p01', 'c03'), rel('p02', 'c03'),
+  // Marriages down the main line
+  rel('g0m', 'g0f', 'spouse', 'current'),
+  rel('g1m', 'g1f', 'spouse', 'current'),
+  rel('g2m', 'g2f', 'spouse', 'current'),
+  rel('g3m', 'g3f', 'spouse', 'current'),
+  rel('g4m', 'g4f', 'spouse', 'current'),
+  rel('g5m', 'g5f', 'spouse', 'current'),
+  rel('g6m', 'g6f', 'spouse', 'current'),
+  // דוד: divorced from יעל, currently married to נעמי
+  rel('g7m', 'g7x', 'spouse', 'ex'),
+  rel('g7m', 'g7f', 'spouse', 'current'),
+  rel('g8m', 'g8f', 'spouse', 'current'),
+  // In-law couple (מיכל's parents)
+  rel('g8il1', 'g8il2', 'spouse', 'current'),
+
+  // Parent-child edges, generation by generation
+  ...child(['g0m', 'g0f'], 'g1m'),
+  ...child(['g1m', 'g1f'], 'g2m'),
+  ...child(['g2m', 'g2f'], 'g3m'),
+  ...child(['g2m', 'g2f'], 'g3s1'),
+  ...child(['g3m', 'g3f'], 'g4m'),
+  ...child(['g4m', 'g4f'], 'g5m'),
+  ...child(['g4m', 'g4f'], 'g5s1'),
+  ...child(['g5m', 'g5f'], 'g6m'),
+  ...child(['g6m', 'g6f'], 'g7s1'),
+  ...child(['g6m', 'g6f'], 'g7m'),
+  ...child(['g6m', 'g6f'], 'g7s2'),
+  // שי — child of the divorced couple
+  ...child(['g7m', 'g7x'], 'g8s1'),
+  ...child(['g7m', 'g7f'], 'g8m'),
+  ...child(['g7m', 'g7f'], 'g8s2'),
+  // מיכל under her own parents (menorah satellite)
+  ...child(['g8il1', 'g8il2'], 'g8f'),
+  ...child(['g8m', 'g8f'], 'g9c1'),
+  ...child(['g8m', 'g8f'], 'g9c2'),
+  ...child(['g8m', 'g8f'], 'g9c3'),
 ]

--- a/src/hooks/useCloseOnBack.ts
+++ b/src/hooks/useCloseOnBack.ts
@@ -1,0 +1,120 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Makes the phone's back button close the topmost open overlay (panel,
+ * modal, popover) instead of leaving the page — an owner request: "back
+ * from an open profile should return to the tree, not to the home page".
+ *
+ * Mechanics: ONE sentinel history entry guards any number of stacked
+ * overlays (a per-overlay entry would desync when React unmounts parent
+ * and child overlays in the same commit). A module-level stack tracks
+ * open overlays; a back press closes the top one and re-arms the
+ * sentinel while any remain.
+ *
+ * The tricky part is that `history.back()` is ASYNC: when the last
+ * overlay closes through its own UI we issue a back() to consume the
+ * sentinel, but a new overlay can register before that pop lands (e.g.
+ * the tree-switcher popover closing in the same commit that opens the
+ * delete-confirm dialog). `pendingConsumes` counts our own in-flight
+ * back() calls so their popstates are swallowed, and arming is deferred
+ * until they land — otherwise we'd push a sentinel on top of a doomed
+ * entry and the bookkeeping would point at the wrong history slot.
+ *
+ * HashRouter only reacts to hash CHANGES, and the sentinel keeps the
+ * URL identical — so router navigation is never affected.
+ */
+
+interface OverlayEntry {
+  id: number
+  close: () => void
+}
+
+const stack: OverlayEntry[] = []
+let nextId = 1
+let sentinelActive = false
+let pendingConsumes = 0
+let listenerInstalled = false
+
+function hasSentinelState(): boolean {
+  const cur = (window.history.state ?? {}) as { __ftOverlay?: boolean }
+  return !!cur.__ftOverlay
+}
+
+function armSentinel() {
+  if (sentinelActive) return
+  // A self-issued back() is still in flight — pushing now would stack a
+  // sentinel on top of the entry that pop is about to remove. The
+  // popstate handler re-arms once the consume lands.
+  if (pendingConsumes > 0) return
+  // Preserve whatever state the router stored for this entry; only tag it.
+  const base = (window.history.state ?? {}) as Record<string, unknown>
+  window.history.pushState({ ...base, __ftOverlay: true }, '')
+  sentinelActive = true
+}
+
+function ensureListener() {
+  if (listenerInstalled || typeof window === 'undefined') return
+  listenerInstalled = true
+  window.addEventListener('popstate', () => {
+    if (pendingConsumes > 0) {
+      // Our own back() landed — swallow it, and re-arm if overlays
+      // opened while it was in flight.
+      pendingConsumes--
+      if (stack.length > 0) armSentinel()
+      return
+    }
+    if (!sentinelActive || stack.length === 0) return
+    // A real user back press consumed the sentinel entry.
+    sentinelActive = false
+    const top = stack.pop()
+    top?.close()
+    // More overlays still open → push a fresh sentinel so the NEXT back
+    // also closes an overlay rather than leaving the page.
+    if (stack.length > 0) armSentinel()
+  })
+}
+
+function register(close: () => void): number {
+  ensureListener()
+  const id = nextId++
+  stack.push({ id, close })
+  armSentinel()
+  return id
+}
+
+function unregister(id: number) {
+  const idx = stack.findIndex((e) => e.id === id)
+  if (idx === -1) return // already removed by the popstate handler
+  stack.splice(idx, 1)
+  if (stack.length > 0 || !sentinelActive) return
+  // Last overlay closed through its own UI (X button / backdrop): the
+  // sentinel entry is still on the history stack — consume it so the
+  // next back press doesn't no-op. Guard: if the app already navigated
+  // elsewhere (overlay unmounted by a route change), the current entry
+  // is the router's, not our sentinel — going back would yank the user
+  // off the page they just navigated to.
+  sentinelActive = false
+  if (hasSentinelState()) {
+    pendingConsumes++
+    window.history.back()
+  }
+}
+
+/**
+ * Hook an overlay's open state to the back button. While `open` is
+ * true, the next back press calls `onClose` instead of navigating.
+ * Safe to stack — back closes overlays top-down, one per press.
+ */
+export function useCloseOnBack(open: boolean, onClose: () => void) {
+  const closeRef = useRef(onClose)
+  // Keep the latest close callback without re-registering the overlay
+  // (ref write happens in an effect — react-hooks v7 forbids render-time
+  // ref mutation).
+  useEffect(() => { closeRef.current = onClose }, [onClose])
+
+  useEffect(() => {
+    if (!open) return
+    const id = register(() => closeRef.current())
+    return () => unregister(id)
+  }, [open])
+}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -680,6 +680,70 @@ export const translations = {
     panelCopyToTreeNote: 'הפרטים האישיים יועתקו. קשרים משפחתיים לא יועתקו.',
     panelCopyToTreeDone: 'הועתק בהצלחה!',
     panelCopyToTreeMain: 'עץ ראשי',
+
+    // Empty tree CTA (TreeView)
+    treeEmptyAddFirst: 'הוספת בן המשפחה הראשון',
+
+    // Edit-mode coach mark
+    editCoachTitle: 'מצב עריכה פעיל',
+    editCoachIntro: 'ליד כל כרטיס מופיעים כפתורי + להוספת קרובים:',
+    editCoachParent: 'פלוס למעלה — הוספת אבא או אמא',
+    editCoachChild: 'פלוס למטה — הוספת בן או בת',
+    editCoachSibling: 'פלוס מימין — הוספת אח או אחות',
+    editCoachSpouse: 'פלוס משמאל — הוספת בן או בת זוג',
+    editCoachGotIt: 'הבנתי!',
+
+    // Help menu ("?")
+    helpMenuTooltip: 'עזרה',
+    helpMenuTitle: 'עזרה ותמיכה',
+    helpTour: 'מצב למידה',
+    helpTourDesc: 'סיור מודרך צעד-אחר-צעד על המסך',
+    helpFaq: 'שאלות נפוצות',
+    helpFaqDesc: 'תשובות קצרות לשאלות חוזרות',
+    helpReport: 'דיווח למנהל',
+    helpReportDesc: 'שליחת שאלה או דיווח על תקלה',
+
+    // FAQ
+    faqTitle: 'שאלות נפוצות',
+    faqClose: 'סגור',
+    faqQ1: 'איך מוסיפים בן משפחה חדש?',
+    faqA1: 'לוחצים על כפתור ה-+ הכחול בסרגל העליון, או מפעילים מצב עריכה (כפתור העיפרון למטה) ולוחצים על אחד מכפתורי ה-+ שמופיעים סביב כל כרטיס.',
+    faqQ2: 'איך עורכים פרטים של בן משפחה?',
+    faqA2: 'לוחצים על הכרטיס שלו בעץ — נפתח חלון הפרופיל, ושם לוחצים על כפתור העריכה. אפשר לעדכן שמות, תאריכים, תמונה וסיפור חיים.',
+    faqQ3: 'איך מסמנים גירושין או פטירה?',
+    faqA3: 'גירושין: בחלון הפרופיל נכנסים ל"ניהול קשרים", בוחרים את בן/בת הזוג ומחליפים את הסטטוס ל"גרושים".\nפטירה: בעריכת הפרופיל מוסיפים תאריך פטירה.',
+    faqQ4: 'למה אני לא רואה גרושים בעץ?',
+    faqA4: 'כברירת מחדל בני זוג לשעבר אינם מוצגים, כדי שהעץ יישאר נקי. בסינון המתקדם מפעילים "הצג גירושים" — והם יופיעו כתג קטן ליד בן הזוג לשעבר.',
+    faqQ5: 'איך עוברים בין עצים או יוצרים עץ חדש?',
+    faqA5: 'לוחצים על הכפתור עם הנקודה הצבעונית בסרגל העליון — נפתחת רשימת העצים שלך, ובתחתיתה "צור עץ חדש".',
+    faqQ6: 'איך מתמקדים באדם אחד ובמשפחה הקרובה שלו?',
+    faqA6: 'פותחים את התפריט הצף (כפתור שלושת הקווים) ולוחצים על "מיקוד דינמי". בוחרים אדם — ורואים רק אותו עם ההורים, בני הזוג והילדים שלו.',
+    faqQ7: 'איך מחפשים מישהו בעץ?',
+    faqA7: 'לוחצים על כפתור הזכוכית המגדלת בסרגל העליון ומקלידים שם. לחיצה על תוצאה תקפיץ אתכם אליה בעץ.',
+    faqQ8: 'האם התמונות שאני מעלה נשמרות?',
+    faqA8: 'בשלב זה תמונות שמועלות מהמכשיר נשמרות מקומית בלבד. שמירת תמונות קבועה בענן תתווסף בהמשך.',
+
+    // Feedback (report to admin)
+    feedbackTitle: 'דיווח למנהל המערכת',
+    feedbackDesc: 'ההודעה תישלח ישירות למנהל ותטופל בהקדם.',
+    feedbackCategoryBug: 'דיווח על תקלה',
+    feedbackCategoryQuestion: 'שאלה',
+    feedbackPlaceholderBug: 'מה קרה? תארו מה ניסיתם לעשות ומה השתבש…',
+    feedbackPlaceholderQuestion: 'מה תרצו לשאול?',
+    feedbackSend: 'שליחה',
+    feedbackSent: 'ההודעה נשלחה!',
+    feedbackSentDesc: 'תודה! המנהל יראה את הפנייה במסך הניהול ויטפל בה.',
+
+    // Admin reports tab
+    adminTabReports: 'דיווחים',
+    adminReportsTitle: 'באגים ודיווחים',
+    adminReportsDesc: 'פניות שנשלחו מכפתור העזרה — תקלות ושאלות מהמשתמשים',
+    adminReportsEmpty: 'אין דיווחים כרגע. כל הכבוד!',
+    feedbackStatusResolved: 'טופל',
+    feedbackMarkResolved: 'סמן כטופל',
+    feedbackReopen: 'פתח מחדש',
+    feedbackDelete: 'מחק',
+    feedbackDeleteConfirm: 'למחוק את הדיווח לצמיתות?',
   },
 
   en: {
@@ -1349,6 +1413,70 @@ export const translations = {
     panelCopyToTreeNote: 'Personal details will be copied. Family relationships will not be included.',
     panelCopyToTreeDone: 'Copied successfully!',
     panelCopyToTreeMain: 'Main tree',
+
+    // Empty tree CTA (TreeView)
+    treeEmptyAddFirst: 'Add the first family member',
+
+    // Edit-mode coach mark
+    editCoachTitle: 'Edit mode is on',
+    editCoachIntro: 'Small + buttons now appear around every card:',
+    editCoachParent: '+ above — add a father or mother',
+    editCoachChild: '+ below — add a son or daughter',
+    editCoachSibling: '+ on one side — add a sibling',
+    editCoachSpouse: '+ on the other side — add a spouse',
+    editCoachGotIt: 'Got it!',
+
+    // Help menu ("?")
+    helpMenuTooltip: 'Help',
+    helpMenuTitle: 'Help & support',
+    helpTour: 'Learning mode',
+    helpTourDesc: 'Step-by-step guided tour on screen',
+    helpFaq: 'FAQ',
+    helpFaqDesc: 'Short answers to common questions',
+    helpReport: 'Contact admin',
+    helpReportDesc: 'Send a question or report a bug',
+
+    // FAQ
+    faqTitle: 'Frequently asked questions',
+    faqClose: 'Close',
+    faqQ1: 'How do I add a family member?',
+    faqA1: 'Tap the blue + button in the top bar, or enable edit mode (the pencil button at the bottom) and tap one of the + buttons around any card.',
+    faqQ2: 'How do I edit someone’s details?',
+    faqA2: 'Tap their card on the tree — the profile panel opens; tap the edit button there. You can update names, dates, a photo and a life story.',
+    faqQ3: 'How do I mark a divorce or a death?',
+    faqA3: 'Divorce: open the profile panel → "Manage relationships", pick the spouse and switch the status to "Divorced".\nDeath: add a death date in the profile editor.',
+    faqQ4: 'Why don’t I see divorced spouses on the tree?',
+    faqA4: 'Former spouses are hidden by default to keep the tree clean. Enable "Show divorces" in the advanced filter — they appear as a small badge next to their former partner.',
+    faqQ5: 'How do I switch trees or create a new one?',
+    faqA5: 'Tap the button with the colored dot in the top bar — your tree list opens, with "Create new tree" at the bottom.',
+    faqQ6: 'How do I focus on one person and their close family?',
+    faqA6: 'Open the floating menu (the three-lines button) and tap "Focused mode". Pick a person to see only them with their parents, spouses and children.',
+    faqQ7: 'How do I search for someone?',
+    faqA7: 'Tap the magnifying-glass button in the top bar and type a name. Tapping a result jumps to them on the tree.',
+    faqQ8: 'Are uploaded photos saved permanently?',
+    faqA8: 'For now, photos uploaded from your device are stored locally only. Permanent cloud photo storage is coming later.',
+
+    // Feedback (report to admin)
+    feedbackTitle: 'Report to the admin',
+    feedbackDesc: 'Your message goes directly to the system admin.',
+    feedbackCategoryBug: 'Report a bug',
+    feedbackCategoryQuestion: 'Question',
+    feedbackPlaceholderBug: 'What happened? Describe what you tried and what went wrong…',
+    feedbackPlaceholderQuestion: 'What would you like to ask?',
+    feedbackSend: 'Send',
+    feedbackSent: 'Message sent!',
+    feedbackSentDesc: 'Thanks! The admin will see your report in the admin dashboard.',
+
+    // Admin reports tab
+    adminTabReports: 'Reports',
+    adminReportsTitle: 'Bugs & reports',
+    adminReportsDesc: 'Messages sent from the help button — bugs and user questions',
+    adminReportsEmpty: 'No reports right now. Well done!',
+    feedbackStatusResolved: 'Resolved',
+    feedbackMarkResolved: 'Mark resolved',
+    feedbackReopen: 'Reopen',
+    feedbackDelete: 'Delete',
+    feedbackDeleteConfirm: 'Permanently delete this report?',
   },
 } as const
 

--- a/src/layout/__tests__/demoSeed.test.ts
+++ b/src/layout/__tests__/demoSeed.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { computeLayout, validateLayout } from '../index'
+import { ADLER_MEMBERS, ADLER_RELATIONSHIPS } from '../../data/adlerFamily'
+
+/**
+ * The demo seed doubles as the pilot dataset AND as a layout fixture:
+ * 10 generations, sibling branches, a divorce with a shared child, and
+ * an in-law (menorah) satellite. If the engine ever regresses on any of
+ * those shapes, this is the first place it shows up — and it also
+ * guards the seed itself against accidental edits that would break the
+ * live demo tree (scripts/seed-demo-tree.ts pushes this exact data).
+ */
+describe('demo seed — 10-generation pilot dataset', () => {
+  const result = computeLayout({
+    members: ADLER_MEMBERS,
+    relationships: ADLER_RELATIONSHIPS,
+  })
+
+  it('lays out with zero data issues and zero invariant violations', () => {
+    expect(result.issues).toEqual([])
+    expect(validateLayout(result).map((v) => `${v.rule}: ${v.message}`)).toEqual([])
+  })
+
+  it('spans 10 generation rows from the 1742 patriarch to the 2016 child', () => {
+    const ids = new Set(result.nodes.map((n) => n.member.id))
+    expect(ids.has('g0m')).toBe(true) // oldest ancestor placed
+    expect(ids.has('g9c3')).toBe(true) // youngest descendant placed
+    const distinctRows = new Set(result.nodes.map((n) => n.y)).size
+    expect(distinctRows).toBeGreaterThanOrEqual(10)
+  })
+
+  it('contains the feature coverage the pilot needs', () => {
+    // At least one divorce…
+    expect(
+      ADLER_RELATIONSHIPS.some((r) => r.type === 'spouse' && r.status === 'ex'),
+    ).toBe(true)
+    // …several deceased members…
+    expect(ADLER_MEMBERS.filter((m) => m.death_date).length).toBeGreaterThanOrEqual(5)
+    // …and illustrated avatars on most members.
+    expect(
+      ADLER_MEMBERS.filter((m) => m.photo_url?.startsWith('https://')).length,
+    ).toBeGreaterThanOrEqual(20)
+  })
+})

--- a/src/pages/TreePage.tsx
+++ b/src/pages/TreePage.tsx
@@ -11,10 +11,13 @@ import AddMemberModal from '../components/AddMemberModal'
 import TreeSearchModal from '../components/TreeSearchModal'
 import TreeSwitcher from '../components/TreeSwitcher'
 import EditModeToggle from '../components/EditModeToggle'
+import EditModeCoachMark from '../components/EditModeCoachMark'
+import HelpMenu from '../components/help/HelpMenu'
 import { useEffect, useMemo, useState } from 'react'
 import AdvancedFilter from '../components/views/AdvancedFilter'
 import { DEFAULT_FILTERS, type FilterState } from '../components/views/filterState'
 import { useBrowserZoom } from '../hooks/useBrowserZoom'
+import { useCloseOnBack } from '../hooks/useCloseOnBack'
 import { useHorizontalSwipe } from '../hooks/useHorizontalSwipe'
 import Tooltip from '../components/Tooltip'
 import TutorialOverlay, { type TourStep } from '../components/TutorialOverlay'
@@ -77,6 +80,11 @@ export default function TreePage({ demoMode }: Props) {
   // dominate the viewport. We apply an inverse transform so the panel
   // stays at a roughly constant physical size regardless of zoom.
   const browserZoom = useBrowserZoom()
+
+  // Phone back button: close the member profile panel and stay on the
+  // tree instead of navigating away (owner request — back from an open
+  // profile used to land on the home page).
+  useCloseOnBack(!!selectedMemberId, () => setSelectedMemberId(null))
 
   // Tutorial overlay tailored to the TREE page itself. The user said
   // a guided walkthrough is "even more important" here than on the
@@ -275,7 +283,11 @@ export default function TreePage({ demoMode }: Props) {
       <div className="relative">
         {viewMode === 'tree' && (
           <>
-            <TreeView filters={filters} onMatchedCount={setMatchedCount} />
+            <TreeView
+              filters={filters}
+              onMatchedCount={setMatchedCount}
+              onAddFirst={() => setAddOpen(true)}
+            />
 
             {/* Floating-controls hamburger.
                 The three tree-page chips (Focused-Centric, Filters,
@@ -338,31 +350,14 @@ export default function TreePage({ demoMode }: Props) {
               />
             )}
 
-            {/* Tutorial replay pill — only visible when the hamburger
-                is expanded. Previously a "?" pill in the top chrome
-                bar, but it was eating the family-name's space. Now
-                lives next to the hamburger so the top bar stays
-                clean and the user finds it together with the other
-                advanced controls. */}
+            {/* Help "?" — last in the vertical chip stack. Absolute in
+                the SAME container as the filter chip so spacing stays
+                uniform (144 → 196 → 248); the previous `fixed` version
+                measured against the viewport and floated with a visible
+                gap (owner bug report). Opens the help hub: guided tour,
+                FAQ, report-to-admin. */}
             {treeControlsExpanded && !hideChrome && (
-              // Minimal "?" icon — last in the vertical stack. NOTE the
-              // chips above it are `absolute` inside the tree container
-              // (origin ~31px lower than the viewport) while this button
-              // is `fixed`, so its offset compensates: focus chip ends at
-              // ~viewport 270; 300 leaves a clean gap below it.
-              <div className={`fixed z-30 no-print ${isRTL(lang) ? 'left-3' : 'right-3'}`} style={{ top: 'calc(env(safe-area-inset-top, 0px) + 300px)' }}>
-                <Tooltip content={t.tipTreeTutorial} placement="bottom" align="end">
-                  <motion.button
-                    type="button"
-                    whileTap={{ scale: 0.94 }}
-                    onClick={() => setTreeTutorialOpen(true)}
-                    aria-label={t.tipTreeTutorial}
-                    className="w-9 h-9 rounded-full bg-white/95 border border-white/70 shadow-glass text-[#007AFF] flex items-center justify-center hover:bg-white transition"
-                  >
-                    <span className="text-base font-bold" aria-hidden>?</span>
-                  </motion.button>
-                </Tooltip>
-              </div>
+              <HelpMenu onStartTour={() => setTreeTutorialOpen(true)} />
             )}
           </>
         )}
@@ -521,6 +516,9 @@ export default function TreePage({ demoMode }: Props) {
           per-card "+" buttons would be misplaced there. Hidden in
           fullscreen + focused mode to keep the canvas clean. */}
       {!hideChrome && viewMode === 'tree' && <EditModeToggle />}
+      {/* Edit-mode explainer balloon — pops when the mode turns on,
+          until the user confirms they understood the four "+" buttons. */}
+      {!hideChrome && viewMode === 'tree' && <EditModeCoachMark />}
 
       {/* Interactive tree-page tutorial. Auto-launches on the user's
           very first visit to the tree (different localStorage key

--- a/src/store/useFamilyStore.ts
+++ b/src/store/useFamilyStore.ts
@@ -3,7 +3,7 @@ import { supabase, isSupabaseConfigured } from '../lib/supabase'
 import { canApproveEditRequests, isAdmin } from '../lib/permissions'
 import type {
   Member, Relationship, EditRequest, ViewMode, Profile,
-  AccessRequest, UserRole, FamilyTree, MemberNote,
+  AccessRequest, UserRole, FamilyTree, MemberNote, FeedbackItem,
 } from '../types'
 
 // Surface Supabase failures to the UI. The "נשמר מקומית — סנכרון
@@ -191,6 +191,16 @@ interface FamilyState {
   addNote: (note: Omit<MemberNote, 'id' | 'created_at'>) => Promise<MemberNote | null>
   updateNote: (id: string, patch: Partial<MemberNote>) => Promise<void>
   deleteNote: (id: string) => Promise<void>
+
+  // ── Feedback (help "?" → bug report / question to the admin) ───────
+  /** Admin-facing list; regular users only ever append via addFeedback. */
+  feedback: FeedbackItem[]
+  fetchFeedback: () => Promise<void>
+  addFeedback: (
+    item: Pick<FeedbackItem, 'author_id' | 'author_name' | 'category' | 'body' | 'context'>,
+  ) => Promise<FeedbackItem | null>
+  updateFeedback: (id: string, patch: Partial<FeedbackItem>) => Promise<void>
+  deleteFeedback: (id: string) => Promise<void>
 }
 
 export const useFamilyStore = create<FamilyState>((set, get) => ({
@@ -899,6 +909,81 @@ export const useFamilyStore = create<FamilyState>((set, get) => ({
     try { await supabase.from('member_notes').delete().eq('id', id) } catch (err) {
       reportSupabaseFailure('deleteNote', err)
     }
+  },
+
+  // ── Feedback ───────────────────────────────────────────────────────
+  // Same optimistic pattern as notes. In demo mode the optimistic row
+  // is the source of truth and the App.tsx localStorage subscriber
+  // persists it, so the demo admin sees their own test reports too.
+  feedback: [],
+  fetchFeedback: async () => {
+    if (!isSupabaseConfigured) return
+    const { data, error } = await supabase
+      .from('feedback')
+      .select('*')
+      .order('created_at', { ascending: false })
+    if (error) {
+      reportSupabaseFailure('fetchFeedback', error, 'read')
+      return
+    }
+    if (!Array.isArray(data)) return
+    const serverRows = data as FeedbackItem[]
+    const serverIds = new Set(serverRows.map((f) => f.id))
+    // Preserve mid-flight optimistic rows (synthetic `fb-` ids).
+    const localOptimistic = get().feedback.filter(
+      (f) => f.id.startsWith('fb-') && !serverIds.has(f.id),
+    )
+    set({ feedback: [...serverRows, ...localOptimistic] })
+  },
+  addFeedback: async (item) => {
+    const localId = `fb-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
+    const optimistic: FeedbackItem = {
+      ...item,
+      id: localId,
+      status: 'open',
+      created_at: new Date().toISOString(),
+    }
+    set((s) => ({ feedback: [optimistic, ...s.feedback] }))
+    if (!isSupabaseConfigured) return optimistic
+    try {
+      const { data, error } = await supabase
+        .from('feedback')
+        .insert({
+          author_id: item.author_id,
+          author_name: item.author_name,
+          category: item.category,
+          body: item.body,
+          context: item.context ?? null,
+        })
+        .select()
+        .single()
+      if (error) reportSupabaseFailure('addFeedback', error)
+      if (data) {
+        set((s) => ({
+          feedback: s.feedback.map((f) => (f.id === localId ? (data as FeedbackItem) : f)),
+        }))
+        return data as FeedbackItem
+      }
+    } catch (err) { reportSupabaseFailure('addFeedback', err) }
+    return optimistic
+  },
+  updateFeedback: async (id, patch) => {
+    set((s) => ({
+      feedback: s.feedback.map((f) => (f.id === id ? { ...f, ...patch } : f)),
+    }))
+    if (!isSupabaseConfigured) return
+    try {
+      const { error } = await supabase.from('feedback').update(patch).eq('id', id)
+      if (error) reportSupabaseFailure('updateFeedback', error)
+    } catch (err) { reportSupabaseFailure('updateFeedback', err) }
+  },
+  deleteFeedback: async (id) => {
+    set((s) => ({ feedback: s.feedback.filter((f) => f.id !== id) }))
+    if (!isSupabaseConfigured) return
+    try {
+      const { error } = await supabase.from('feedback').delete().eq('id', id)
+      if (error) reportSupabaseFailure('deleteFeedback', error)
+    } catch (err) { reportSupabaseFailure('deleteFeedback', err) }
   },
 
   // ── Tree-view floating-controls visibility ─────────────────────────

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -173,6 +173,28 @@ export interface EditRequest {
 }
 
 /**
+ * Feedback sent from the help ("?") menu — a bug report or a question
+ * addressed to the system admin. Surfaces in the admin dashboard under
+ * the "reports" tab; regular users only ever write these, never read
+ * others'. `author_name` is denormalised like MemberNote's so the row
+ * stays meaningful even if the profile is renamed or deleted.
+ */
+export type FeedbackCategory = 'bug' | 'question'
+export type FeedbackStatus = 'open' | 'resolved'
+
+export interface FeedbackItem {
+  id: string
+  author_id: string
+  author_name: string
+  category: FeedbackCategory
+  body: string
+  /** Where the report was sent from (route hash) — helps reproduce. */
+  context?: string | null
+  status: FeedbackStatus
+  created_at: string
+}
+
+/**
  * Note left on a member's profile by a family-tree user — short
  * `comment` (a few sentences) or longer `memory` (anecdote / story).
  * Both render in the same Notes tab; `kind` only changes the visual


### PR DESCRIPTION
## What's in this batch
Owner-reported bug batch #2 — all items verified in a real browser (demo mode at localhost:5173).

- **Help "?" hub** — the chip now sits flush in the floating stack (144/196/248, was a detached fixed:300). Opens a 3-option menu: guided-tour replay, built-in FAQ accordion, and a report-to-admin form.
- **Admin "Reports" tab** — new `feedback` table (`migrations/012_feedback.sql`; RLS: users insert their own, only admins read/triage) + UI with resolve / reopen / delete.
- **Rich demo seed** — 30 members across 10 generations (born 1742-2016): fake Hebrew names, dates, bios, illustrated DiceBear avatars, deceased members, one divorce with a shared child, and an in-law (menorah) satellite. Pinned by a new engine test (zero validateLayout violations). `scripts/seed-demo-tree.ts` pushes the same dataset into the live demo tree later (transactional, `--dry-run`/`--yes` gated).
- **Delete-tree dialog layering** — the confirm dialog now closes the switcher popover and renders at z-[110] (it used to paint UNDER the z-[60] popover).
- **Tree-switcher popover** — viewport-centred via a fixed flex wrapper; no longer clips off-screen in RTL.
- **Empty tree CTA** — big central "+" that opens the add-member flow.
- **Edit-mode coach mark** — one-time balloon explaining the four per-card "+" buttons, with language-aware side arrows; "got it" persists to localStorage.
- **Mobile back button** — new `useCloseOnBack` hook: a single sentinel history entry makes hardware back close the top overlay (profile panel, modals, popovers, focused mode, tour) instead of leaving the tree. Handles the async `history.back()` race when overlays hand off in one commit.

## Gates
typecheck clean · 54/54 tests green (3 new) · eslint 0 errors · production build OK

## After merge
1. Apply `migrations/012_feedback.sql` to prod (script ready).
2. Snapshot backup, then reseed the live demo tree via `scripts/seed-demo-tree.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)