### PR TITLE
feat(auth): batch 3 - Google sign-in, opt-in TOTP 2FA, popover z-fix, DB scripts

### DIFF
--- a/scripts/restore-real-family.ts
+++ b/scripts/restore-real-family.ts
@@ -1,0 +1,217 @@
+/**
+ * Restore the REAL Adler family (~73 members) into a NEW tree on the
+ * live Supabase project.
+ *
+ * Source of truth: the pre-rewrite seed file preserved in git history
+ * (commit 83c7aaa, last version before "chore(demo): replace 84-member
+ * seed with 7-member nuclear family"). The data is extracted at
+ * runtime via `git show` so the real names do NOT live in the current
+ * working tree.
+ *
+ * Usage:
+ *   npx tsx scripts/restore-real-family.ts --dry-run
+ *   npx tsx scripts/restore-real-family.ts --yes
+ *
+ * What it does (one transaction):
+ *   1. Creates the tree "משפחת אדלר" owned by the admin profile
+ *      (errors out if a tree by that name already exists — rename or
+ *      delete it first).
+ *   2. Inserts all members from the historical seed with fresh UUIDs.
+ *   3. Re-links all relationships. The historical data predates spouse
+ *      statuses; every spouse edge imports as 'current' EXCEPT
+ *      לאה צירל ↔ נתנאל (her FIRST husband per the historical bio
+ *      comment) which imports as 'ex' so the layout doesn't flag two
+ *      current spouses. The owner should review this in the app.
+ */
+import { Client } from 'pg'
+import { execSync } from 'child_process'
+import { readFileSync, writeFileSync, existsSync, rmSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath, pathToFileURL } from 'url'
+
+const SOURCE_COMMIT = '83c7aaa'
+const TREE_NAME = 'משפחת אדלר'
+const TREE_COLOR = '#34C759'
+
+const args = process.argv.slice(2)
+const dryRun = args.includes('--dry-run')
+const confirmed = args.includes('--yes')
+if (!dryRun && !confirmed) {
+  console.error('Refusing to modify the live DB without --yes (use --dry-run to preview).')
+  process.exit(1)
+}
+
+const here = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(here, '..')
+
+// ── 1. Extract the historical seed module and import it ─────────────
+const oldSource = execSync(`git show ${SOURCE_COMMIT}:src/data/adlerFamily.ts`, {
+  cwd: repoRoot,
+  encoding: 'utf8',
+})
+// The historical file imports types from '../types' — rewrite the
+// import so the temp module (which lives in scripts/) resolves it.
+const patched = oldSource.replace("from '../types'", "from '../src/types'")
+const tmpFile = join(repoRoot, 'scripts', '.real-family.tmp.ts')
+writeFileSync(tmpFile, patched, 'utf8')
+
+interface OldMember {
+  id: string
+  first_name: string
+  last_name: string
+  nickname?: string
+  bio?: string
+  birth_date?: string
+  death_date?: string
+  gender?: string
+  birth_order?: number | null
+  lineage?: string | null
+  hidden?: boolean
+}
+interface OldRel {
+  id: string
+  member_a_id: string
+  member_b_id: string
+  type: string
+  status?: string | null
+}
+
+const mod = (await import(pathToFileURL(tmpFile).href)) as {
+  ADLER_MEMBERS: OldMember[]
+  ADLER_RELATIONSHIPS: OldRel[]
+}
+const members = mod.ADLER_MEMBERS
+const rels = mod.ADLER_RELATIONSHIPS
+rmSync(tmpFile)
+console.log(`Loaded historical seed: ${members.length} members, ${rels.length} relationships`)
+
+// ── 2. Connection (same strategy as run-migration.ts) ───────────────
+const PROJECT_REF = 'wkbdqdytfjycbbcnzjuv'
+const DB_PASSWORD = 'Yakiradler1123'
+const cacheFile = join(here, '.region-cache')
+
+async function tryConnect(opts: { host: string; port: number; user: string; label: string }): Promise<Client | null> {
+  const c = new Client({
+    host: opts.host,
+    port: opts.port,
+    database: 'postgres',
+    user: opts.user,
+    password: DB_PASSWORD,
+    ssl: { rejectUnauthorized: false },
+    connectionTimeoutMillis: 6000,
+  })
+  try {
+    await c.connect()
+    console.log(`✓ Connected via ${opts.label}`)
+    return c
+  } catch (e) {
+    console.log(`  ✗ ${opts.label}: ${(e instanceof Error ? e.message : String(e)).slice(0, 110)}`)
+    try { await c.end() } catch { /* ignore */ }
+    return null
+  }
+}
+
+async function connect(): Promise<Client> {
+  const direct = await tryConnect({
+    host: `db.${PROJECT_REF}.supabase.co`,
+    port: 5432,
+    user: 'postgres',
+    label: `direct db.${PROJECT_REF}.supabase.co:5432`,
+  })
+  if (direct) return direct
+  const cached = process.env.SUPABASE_POOLER_REGION
+    ?? (existsSync(cacheFile) ? readFileSync(cacheFile, 'utf8').trim() : '')
+  if (cached) {
+    const [prefix, ...rest] = cached.split(':')
+    const [poolerPrefix, region] = rest.length ? [prefix, rest.join(':')] : ['aws-1', cached]
+    const c = await tryConnect({
+      host: `${poolerPrefix}-${region}.pooler.supabase.com`,
+      port: 6543,
+      user: `postgres.${PROJECT_REF}`,
+      label: `pooler ${poolerPrefix}-${region} (cached)`,
+    })
+    if (c) return c
+  }
+  throw new Error('Could not reach Supabase — set SUPABASE_POOLER_REGION (e.g. eu-central-1) and re-run.')
+}
+
+const c = await connect()
+try {
+  // Owner = the admin profile (first admin row).
+  const admin = await c.query(
+    `select id, full_name from public.profiles where role = 'admin' order by created_at limit 1`,
+  )
+  if (admin.rows.length === 0) throw new Error('No admin profile found')
+  const ownerId: string = admin.rows[0].id
+  console.log(`Owner: ${admin.rows[0].full_name} (${ownerId})`)
+
+  const existing = await c.query('select id from public.family_trees where name = $1', [TREE_NAME])
+  if (existing.rows.length > 0) {
+    console.error(`✗ A tree named "${TREE_NAME}" already exists (${existing.rows[0].id}). Rename it first (the demo-reseed step does that).`)
+    process.exit(1)
+  }
+
+  if (dryRun) {
+    console.log(`--dry-run: would create tree "${TREE_NAME}" with ${members.length} members + ${rels.length} relationships. No changes made.`)
+    process.exit(0)
+  }
+
+  await c.query('begin')
+
+  const tree = await c.query(
+    `insert into public.family_trees (name, description, color, created_by)
+     values ($1, $2, $3, $4) returning id`,
+    [TREE_NAME, 'העץ המשפחתי האמיתי', TREE_COLOR, ownerId],
+  )
+  const treeId: string = tree.rows[0].id
+  console.log(`  created tree ${treeId}`)
+
+  const idMap = new Map<string, string>()
+  for (const m of members) {
+    const res = await c.query(
+      `insert into public.members
+         (first_name, last_name, nickname, birth_date, death_date, bio,
+          gender, birth_order, lineage, hidden, tree_id, created_by)
+       values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+       returning id`,
+      [
+        m.first_name, m.last_name ?? '', m.nickname ?? null,
+        m.birth_date ?? null, m.death_date ?? null, m.bio ?? null,
+        m.gender ?? null, m.birth_order ?? null, m.lineage ?? null,
+        m.hidden ?? false, treeId, ownerId,
+      ],
+    )
+    idMap.set(m.id, res.rows[0].id)
+  }
+  console.log(`  inserted ${idMap.size} members`)
+
+  let relCount = 0
+  for (const r of rels) {
+    const a = idMap.get(r.member_a_id)
+    const b = idMap.get(r.member_b_id)
+    if (!a || !b) throw new Error(`Relationship references unknown member: ${r.member_a_id} → ${r.member_b_id}`)
+    // Historical data predates spouse statuses. לאה צירל (c01) had two
+    // husbands; her FIRST (s01, per the bio comment) imports as 'ex'
+    // so the tree doesn't carry two current spouses. Owner to verify.
+    const status =
+      r.type === 'spouse'
+        ? (r.member_a_id === 'c01' && r.member_b_id === 's01' ? 'ex' : (r.status ?? 'current'))
+        : null
+    await c.query(
+      `insert into public.relationships (member_a_id, member_b_id, type, status)
+       values ($1,$2,$3,$4)`,
+      [a, b, r.type, status],
+    )
+    relCount++
+  }
+  console.log(`  inserted ${relCount} relationships`)
+
+  await c.query('commit')
+  console.log(`✓ Real family restored into tree "${TREE_NAME}".`)
+} catch (e) {
+  try { await c.query('rollback') } catch { /* ignore */ }
+  console.error('✗ Restore failed (rolled back):', e)
+  process.exitCode = 1
+} finally {
+  await c.end()
+}

--- a/scripts/seed-demo-tree.ts
+++ b/scripts/seed-demo-tree.ts
@@ -5,7 +5,11 @@
  *
  * Usage:
  *   npx tsx scripts/seed-demo-tree.ts --tree "משפחת אדלר" --dry-run
- *   npx tsx scripts/seed-demo-tree.ts --tree "משפחת אדלר" --yes
+ *   npx tsx scripts/seed-demo-tree.ts --tree "משפחת אדלר" --rename-to "עץ דמו" --yes
+ *
+ * --rename-to also renames the tree itself (and refreshes its
+ * description/color to the demo branding) — used when the live demo
+ * tree's old name must be freed up for the real family tree.
  *
  * What it does (inside ONE transaction):
  *   1. Resolves the target tree by name (must match exactly one row).
@@ -31,6 +35,7 @@ function argValue(flag: string): string | null {
   return i >= 0 && args[i + 1] ? args[i + 1] : null
 }
 const treeName = argValue('--tree')
+const renameTo = argValue('--rename-to')
 const dryRun = args.includes('--dry-run')
 const confirmed = args.includes('--yes')
 
@@ -137,12 +142,24 @@ try {
   console.log(`  current members: ${existing.rows[0].n} → will be replaced by ${ADLER_MEMBERS.length} seed members`)
   console.log(`  owner (created_by for new rows): ${ownerId}`)
 
+  if (renameTo) console.log(`  tree will be renamed to "${renameTo}"`)
+
   if (dryRun) {
     console.log('--dry-run: no changes made.')
     process.exit(0)
   }
 
   await c.query('begin')
+
+  if (renameTo) {
+    await c.query(
+      `update public.family_trees
+          set name = $1, description = $2, color = $3
+        where id = $4`,
+      [renameTo, '10 דורות — נתוני הדגמה מלאים', '#007AFF', treeId],
+    )
+    console.log(`  renamed tree to "${renameTo}"`)
+  }
 
   // 2) Clear the old population. Relationships cascade from members,
   //    but delete them explicitly first so cross-tree edges (if any)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import PersistenceIndicator from './components/PersistenceIndicator'
 import InstallPrompt from './components/InstallPrompt'
 import VersionUpdateModal from './components/VersionUpdateModal'
 import DevEnvBanner from './components/DevEnvBanner'
+import MfaChallengeGate from './components/security/MfaChallengeGate'
 import { ADLER_MEMBERS, ADLER_RELATIONSHIPS, ADLER_TREES } from './data/adlerFamily'
 import { isPendingOnboarding, clearPendingOnboarding } from './lib/pendingOnboarding'
 import type { Profile } from './types'
@@ -413,6 +414,32 @@ export default function App() {
     }
   }, [profile])
 
+  // ── MFA assurance gate ─────────────────────────────────────────────
+  // A password login on an account with a verified TOTP factor yields
+  // an AAL1 session that must be upgraded to AAL2. The gate replaces
+  // the ENTIRE router until the code is entered, so enforcement can't
+  // be bypassed by typing a URL. Reset-on-session-change is adjusted
+  // during render (react-hooks v7 forbids sync setState in effects);
+  // the async AAL probe sets state from its callback, which is fine.
+  const [mfaGate, setMfaGate] = useState(false)
+  const [prevSession, setPrevSession] = useState<Session | null>(session)
+  if (session !== prevSession) {
+    setPrevSession(session)
+    setMfaGate(false)
+  }
+  useEffect(() => {
+    if (!SUPABASE_CONFIGURED || !session) return
+    let cancelled = false
+    supabase.auth.mfa.getAuthenticatorAssuranceLevel()
+      .then(({ data }) => {
+        if (!cancelled && data) {
+          setMfaGate(data.nextLevel === 'aal2' && data.currentLevel !== 'aal2')
+        }
+      })
+      .catch(() => { /* AAL probe failed — don't lock the user out */ })
+    return () => { cancelled = true }
+  }, [session])
+
   if (authLoading) {
     return (
       <div className="min-h-screen bg-mesh-gradient flex items-center justify-center">
@@ -421,6 +448,16 @@ export default function App() {
           transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
           className="w-8 h-8 border-2 border-[#007AFF]/20 border-t-[#007AFF] rounded-full"
         />
+      </div>
+    )
+  }
+
+  // Second-factor wall — see the mfaGate block above for why this
+  // renders INSTEAD of the router.
+  if (SUPABASE_CONFIGURED && session && mfaGate) {
+    return (
+      <div dir={dir}>
+        <MfaChallengeGate onVerified={() => setMfaGate(false)} />
       </div>
     )
   }

--- a/src/components/security/MfaChallengeGate.tsx
+++ b/src/components/security/MfaChallengeGate.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react'
+import { motion } from 'framer-motion'
+import { supabase } from '../../lib/supabase'
+import { useLang, isRTL } from '../../i18n/useT'
+
+/**
+ * Full-screen gate shown when a signed-in session still needs its
+ * second factor (AAL1 with a verified TOTP factor → next level AAL2).
+ * Rendered by App.tsx INSTEAD of the router, so no protected route can
+ * be reached until the code is entered — enforcement lives here, not
+ * in the login form.
+ */
+export default function MfaChallengeGate({ onVerified }: { onVerified: () => void }) {
+  const { t, lang } = useLang()
+  const rtl = isRTL(lang)
+  const [factorId, setFactorId] = useState<string | null>(null)
+  const [code, setCode] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    ;(async () => {
+      const { data } = await supabase.auth.mfa.listFactors()
+      const totp = (data?.totp ?? []).find((f) => f.status === 'verified')
+      setFactorId(totp?.id ?? null)
+    })()
+  }, [])
+
+  const submit = async () => {
+    if (!factorId || code.length < 6 || busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      const { data: ch, error: chErr } = await supabase.auth.mfa.challenge({ factorId })
+      if (chErr) throw chErr
+      const { error: vErr } = await supabase.auth.mfa.verify({ factorId, challengeId: ch.id, code })
+      if (vErr) throw vErr
+      onVerified()
+    } catch {
+      setError(t.mfaCodeWrong)
+      setCode('')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const cancel = async () => {
+    try { await supabase.auth.signOut() } catch { /* ignore */ }
+    // App.tsx clears the gate when the session drops.
+  }
+
+  return (
+    <div dir={rtl ? 'rtl' : 'ltr'} className="min-h-screen bg-mesh-gradient flex items-center justify-center p-6">
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
+        className="w-full max-w-xs rounded-3xl bg-white shadow-glass-lg p-6 space-y-4 text-center"
+      >
+        <span className="mx-auto w-12 h-12 rounded-2xl bg-[#34C759]/12 flex items-center justify-center">
+          <svg width="22" height="22" viewBox="0 0 15 15" fill="none">
+            <path d="M7.5 1.5l5 2v3.6c0 3-2.1 5.6-5 6.4-2.9-.8-5-3.4-5-6.4V3.5l5-2z" stroke="#34C759" strokeWidth="1.4" strokeLinejoin="round" />
+            <path d="M5.3 7.5l1.5 1.5 2.9-3" stroke="#34C759" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </span>
+        <div>
+          <h1 className="text-sf-headline font-bold text-[#1C1C1E]">{t.mfaGateTitle}</h1>
+          <p className="text-[12px] text-[#8E8E93] mt-1 leading-relaxed">{t.mfaGateDesc}</p>
+        </div>
+        <input
+          autoFocus
+          inputMode="numeric"
+          autoComplete="one-time-code"
+          maxLength={6}
+          value={code}
+          onChange={(e) => setCode(e.target.value.replace(/\D/g, ''))}
+          onKeyDown={(e) => e.key === 'Enter' && submit()}
+          placeholder={t.mfaCodePlaceholder}
+          className="w-full rounded-2xl bg-[#F2F2F7] px-4 py-3 text-center text-[22px] tracking-[0.4em] font-bold text-[#1C1C1E] outline-none focus:ring-2 focus:ring-[#34C759]/40"
+          dir="ltr"
+        />
+        {error && (
+          <p className="text-sf-footnote text-[#FF3B30] bg-[#FF3B30]/8 rounded-lg px-3 py-2">{error}</p>
+        )}
+        <button
+          type="button"
+          disabled={code.length < 6 || busy || !factorId}
+          onClick={submit}
+          className="w-full py-2.5 rounded-2xl bg-gradient-to-r from-[#34C759] to-[#30D158] text-white text-sf-subhead font-bold disabled:opacity-40"
+        >
+          {busy ? '…' : t.mfaGateSubmit}
+        </button>
+        <button
+          type="button"
+          onClick={cancel}
+          className="text-[12px] text-[#8E8E93] font-semibold hover:text-[#1C1C1E] transition"
+        >
+          {t.mfaGateCancel}
+        </button>
+      </motion.div>
+    </div>
+  )
+}

--- a/src/components/security/SecuritySettingsModal.tsx
+++ b/src/components/security/SecuritySettingsModal.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import type { Factor } from '@supabase/supabase-js'
+import { supabase, isSupabaseConfigured } from '../../lib/supabase'
+import { useLang, isRTL } from '../../i18n/useT'
+import { useCloseOnBack } from '../../hooks/useCloseOnBack'
+
+/**
+ * Account-security modal — opt-in TOTP two-factor (owner request:
+ * "authenticator verification, only for whoever chooses to secure
+ * their account"). Wraps Supabase's native MFA API:
+ *
+ *   enroll → QR + manual secret → user scans with any authenticator
+ *   app → enters the 6-digit code → factor verified. From then on,
+ *   every password login is held at the MfaChallengeGate (App.tsx)
+ *   until a fresh code is entered.
+ *
+ * Demo mode renders an explanatory placeholder — there's no backend
+ * to enroll against.
+ */
+type Stage = 'list' | 'enroll' | 'verify'
+
+export default function SecuritySettingsModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const { t, lang } = useLang()
+  const rtl = isRTL(lang)
+  const [stage, setStage] = useState<Stage>('list')
+  const [factors, setFactors] = useState<Factor[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [enrollData, setEnrollData] = useState<{ id: string; qr: string; secret: string } | null>(null)
+  const [code, setCode] = useState('')
+
+  useCloseOnBack(open, onClose)
+
+  // Reset the wizard each time the modal opens — adjusted during
+  // render (react-hooks v7 forbids sync setState inside effects).
+  const [prevOpen, setPrevOpen] = useState(open)
+  if (open !== prevOpen) {
+    setPrevOpen(open)
+    if (open) {
+      setStage('list')
+      setError(null)
+      setCode('')
+      setEnrollData(null)
+    }
+  }
+
+  // Load verified factors on open; sweep stale UNVERIFIED leftovers
+  // from abandoned enrollments so they don't block a fresh enroll.
+  useEffect(() => {
+    if (!open || !isSupabaseConfigured) return
+    ;(async () => {
+      setLoading(true)
+      try {
+        const { data, error } = await supabase.auth.mfa.listFactors()
+        if (error) throw error
+        const all = data?.all ?? []
+        for (const f of all) {
+          if (f.status === 'unverified') {
+            try { await supabase.auth.mfa.unenroll({ factorId: f.id }) } catch { /* stale — ignore */ }
+          }
+        }
+        setFactors(all.filter((f) => f.status === 'verified'))
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'error')
+      } finally {
+        setLoading(false)
+      }
+    })()
+  }, [open])
+
+  const startEnroll = async () => {
+    setError(null)
+    setLoading(true)
+    try {
+      const { data, error } = await supabase.auth.mfa.enroll({ factorType: 'totp', friendlyName: 'Authenticator' })
+      if (error) throw error
+      if (!data) throw new Error('enroll failed')
+      const totp = (data as unknown as { totp: { qr_code: string; secret: string } }).totp
+      setEnrollData({ id: data.id, qr: totp.qr_code, secret: totp.secret })
+      setStage('enroll')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'error')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const verifyEnrollment = async () => {
+    if (!enrollData || code.trim().length < 6) return
+    setError(null)
+    setLoading(true)
+    try {
+      const { data: ch, error: chErr } = await supabase.auth.mfa.challenge({ factorId: enrollData.id })
+      if (chErr) throw chErr
+      const { error: vErr } = await supabase.auth.mfa.verify({
+        factorId: enrollData.id,
+        challengeId: ch.id,
+        code: code.trim(),
+      })
+      if (vErr) throw vErr
+      const { data } = await supabase.auth.mfa.listFactors()
+      setFactors((data?.all ?? []).filter((f) => f.status === 'verified'))
+      setEnrollData(null)
+      setCode('')
+      setStage('list')
+    } catch {
+      setError(t.mfaCodeWrong)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const disable = async (factorId: string) => {
+    if (!window.confirm(t.mfaDisableConfirm)) return
+    setLoading(true)
+    setError(null)
+    try {
+      const { error } = await supabase.auth.mfa.unenroll({ factorId })
+      if (error) throw error
+      setFactors((fs) => fs.filter((f) => f.id !== factorId))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'error')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          dir={rtl ? 'rtl' : 'ltr'}
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/40 backdrop-blur-sm p-4"
+          onClick={onClose}
+        >
+          <motion.div
+            initial={{ opacity: 0, scale: 0.94, y: 12 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.94, y: 12 }}
+            transition={{ duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
+            onClick={(e) => e.stopPropagation()}
+            className="w-full max-w-sm max-h-[min(640px,calc(100vh-48px))] overflow-y-auto rounded-3xl bg-white shadow-glass-lg p-5 space-y-4"
+          >
+            <header className="flex items-center justify-between">
+              <h2 className="text-sf-headline font-bold text-[#1C1C1E] flex items-center gap-2">
+                <span className="w-8 h-8 rounded-xl bg-[#34C759]/12 flex items-center justify-center">
+                  <svg width="15" height="15" viewBox="0 0 15 15" fill="none">
+                    <path d="M7.5 1.5l5 2v3.6c0 3-2.1 5.6-5 6.4-2.9-.8-5-3.4-5-6.4V3.5l5-2z" stroke="#34C759" strokeWidth="1.4" strokeLinejoin="round" />
+                    <path d="M5.3 7.5l1.5 1.5 2.9-3" stroke="#34C759" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </span>
+                {t.securityTitle}
+              </h2>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label={t.faqClose}
+                className="w-8 h-8 rounded-full bg-[#F2F2F7] flex items-center justify-center text-[#636366] active:scale-95 transition"
+              >
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                  <path d="M2 2L10 10M10 2L2 10" stroke="#636366" strokeWidth="1.5" strokeLinecap="round" />
+                </svg>
+              </button>
+            </header>
+
+            {!isSupabaseConfigured ? (
+              <p className="text-[12.5px] text-[#8E8E93] leading-relaxed">{t.securityDemoNote}</p>
+            ) : stage === 'list' ? (
+              <>
+                <p className="text-[12.5px] text-[#636366] leading-relaxed">{t.mfaIntro}</p>
+                {factors.length > 0 ? (
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2 rounded-2xl bg-[#34C759]/8 px-3.5 py-3">
+                      <span className="w-2 h-2 rounded-full bg-[#34C759]" aria-hidden />
+                      <span className="text-[13px] font-semibold text-[#1C1C1E]">{t.mfaEnabled}</span>
+                    </div>
+                    <button
+                      type="button"
+                      disabled={loading}
+                      onClick={() => disable(factors[0].id)}
+                      className="w-full py-2.5 rounded-2xl bg-[#FF3B30]/10 text-[#FF3B30] text-sf-subhead font-bold disabled:opacity-40"
+                    >
+                      {t.mfaDisable}
+                    </button>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    disabled={loading}
+                    onClick={startEnroll}
+                    className="w-full py-2.5 rounded-2xl bg-gradient-to-r from-[#34C759] to-[#30D158] text-white text-sf-subhead font-bold disabled:opacity-40"
+                  >
+                    {loading ? '…' : t.mfaEnable}
+                  </button>
+                )}
+              </>
+            ) : (
+              <>
+                <p className="text-[12.5px] text-[#636366] leading-relaxed">{t.mfaScanQr}</p>
+                {enrollData && (
+                  <div className="flex flex-col items-center gap-3">
+                    <img
+                      src={`data:image/svg+xml;utf8,${encodeURIComponent(enrollData.qr)}`}
+                      alt="QR"
+                      className="w-44 h-44 rounded-2xl border border-black/8 bg-white"
+                    />
+                    <p className="text-[10.5px] text-[#8E8E93] text-center break-all px-2" dir="ltr">
+                      {t.mfaManualKey}: <span className="font-mono">{enrollData.secret}</span>
+                    </p>
+                  </div>
+                )}
+                <input
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  maxLength={6}
+                  value={code}
+                  onChange={(e) => setCode(e.target.value.replace(/\D/g, ''))}
+                  placeholder={t.mfaCodePlaceholder}
+                  className="w-full rounded-2xl bg-[#F2F2F7] px-4 py-3 text-center text-[20px] tracking-[0.4em] font-bold text-[#1C1C1E] outline-none focus:ring-2 focus:ring-[#34C759]/40"
+                  dir="ltr"
+                />
+                <button
+                  type="button"
+                  disabled={code.length < 6 || loading}
+                  onClick={verifyEnrollment}
+                  className="w-full py-2.5 rounded-2xl bg-gradient-to-r from-[#34C759] to-[#30D158] text-white text-sf-subhead font-bold disabled:opacity-40"
+                >
+                  {loading ? '…' : t.mfaVerifyAndEnable}
+                </button>
+              </>
+            )}
+
+            {error && (
+              <p className="text-sf-footnote text-[#FF3B30] bg-[#FF3B30]/8 rounded-lg px-3 py-2">{error}</p>
+            )}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/src/components/views/AdvancedFilter.tsx
+++ b/src/components/views/AdvancedFilter.tsx
@@ -99,7 +99,10 @@ export default function AdvancedFilter({
       // `relative` so the absolute popover below positions against
       // the chip and the chip itself doesn't get re-sized when the
       // popover opens.
-      className="absolute top-[144px] z-20 no-print"
+      // z bumps above the sibling chips ("?" help at z-20) and the
+      // bottom nav (z-50) while the popover is open — the help chip
+      // used to paint THROUGH the open filter panel (owner screenshot).
+      className={`absolute top-[144px] no-print ${open ? 'z-[60]' : 'z-20'}`}
       style={{ [rtl ? 'left' : 'right']: 12, position: 'absolute' } as React.CSSProperties}
       data-tour="tree-chip-filter"
     >

--- a/src/components/views/TreeView.tsx
+++ b/src/components/views/TreeView.tsx
@@ -306,7 +306,9 @@ export default function TreeView({
           chip (144 + ~40px chip + gap). */}
       {members.length > 0 && treeControlsExpanded && (
         <div
-          className="absolute z-20 no-print"
+          // Same open-state z bump as the filter chip: the person picker
+          // must paint above the "?" help chip below it.
+          className={`absolute no-print ${showFocusPicker ? 'z-[60]' : 'z-20'}`}
           style={{ top: 196, [rtl ? 'left' : 'right']: 12 } as React.CSSProperties}
           data-tour="tree-chip-focus"
         >

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -744,6 +744,28 @@ export const translations = {
     feedbackReopen: 'פתח מחדש',
     feedbackDelete: 'מחק',
     feedbackDeleteConfirm: 'למחוק את הדיווח לצמיתות?',
+
+    // Social sign-in
+    authOrDivider: 'או',
+    authContinueWithGoogle: 'המשך עם Google',
+
+    // Account security / two-factor (TOTP)
+    securityTitle: 'אבטחת חשבון',
+    securityDemoNote: 'אימות דו-שלבי זמין רק בחשבון אמיתי, לא במצב הדגמה.',
+    mfaIntro: 'אימות דו-שלבי מוסיף שכבת הגנה לחשבון: אחרי הסיסמה תתבקשו להזין קוד מתחלף מאפליקציית אימות בטלפון.',
+    mfaEnabled: 'אימות דו-שלבי פעיל',
+    mfaEnable: 'הפעלת אימות דו-שלבי',
+    mfaDisable: 'כיבוי אימות דו-שלבי',
+    mfaDisableConfirm: 'לכבות את האימות הדו-שלבי? החשבון יהיה מוגן בסיסמה בלבד.',
+    mfaScanQr: 'סרקו את הקוד עם אפליקציית אימות (Google Authenticator, Authy וכדומה) והזינו את הקוד בן 6 הספרות שמופיע בה.',
+    mfaManualKey: 'מפתח להזנה ידנית',
+    mfaCodePlaceholder: '123456',
+    mfaVerifyAndEnable: 'אימות והפעלה',
+    mfaCodeWrong: 'קוד שגוי — נסו שוב',
+    mfaGateTitle: 'אימות דו-שלבי',
+    mfaGateDesc: 'החשבון מוגן. הזינו את הקוד מאפליקציית האימות כדי להמשיך.',
+    mfaGateSubmit: 'אישור',
+    mfaGateCancel: 'התנתקות',
   },
 
   en: {
@@ -1477,6 +1499,28 @@ export const translations = {
     feedbackReopen: 'Reopen',
     feedbackDelete: 'Delete',
     feedbackDeleteConfirm: 'Permanently delete this report?',
+
+    // Social sign-in
+    authOrDivider: 'or',
+    authContinueWithGoogle: 'Continue with Google',
+
+    // Account security / two-factor (TOTP)
+    securityTitle: 'Account security',
+    securityDemoNote: 'Two-factor authentication is available on real accounts only, not in demo mode.',
+    mfaIntro: 'Two-factor authentication adds a protection layer: after your password you will be asked for a rotating code from an authenticator app on your phone.',
+    mfaEnabled: 'Two-factor authentication is on',
+    mfaEnable: 'Enable two-factor authentication',
+    mfaDisable: 'Disable two-factor authentication',
+    mfaDisableConfirm: 'Disable two-factor authentication? Your account will be protected by password only.',
+    mfaScanQr: 'Scan the code with an authenticator app (Google Authenticator, Authy, etc.) and enter the 6-digit code it shows.',
+    mfaManualKey: 'Manual entry key',
+    mfaCodePlaceholder: '123456',
+    mfaVerifyAndEnable: 'Verify & enable',
+    mfaCodeWrong: 'Wrong code — try again',
+    mfaGateTitle: 'Two-factor authentication',
+    mfaGateDesc: 'This account is protected. Enter the code from your authenticator app to continue.',
+    mfaGateSubmit: 'Confirm',
+    mfaGateCancel: 'Sign out',
   },
 } as const
 

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -35,6 +35,24 @@ export default function Auth({ demoMode = false, onDemoEnter }: Props) {
 
   const dir = lang === 'he' ? 'rtl' : 'ltr'
 
+  // OAuth redirect flow — Supabase hands off to Google and returns to
+  // this origin with session tokens in the URL hash; supabase-js's
+  // detectSessionInUrl consumes them and onAuthStateChange in App.tsx
+  // picks the session up. On phones this also gives the user their
+  // device biometrics (fingerprint / face) for free via Google.
+  const signInWithGoogle = async () => {
+    setError(null)
+    try {
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: { redirectTo: `${window.location.origin}/` },
+      })
+      if (error) throw error
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t.genericError)
+    }
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError(null)
@@ -271,6 +289,33 @@ export default function Auth({ demoMode = false, onDemoEnter }: Props) {
               {mode === 'login' ? t.authSubmitLogin : t.authSubmitSignup}
             </motion.button>
           </form>
+
+          {/* Social sign-in — real backend only; the demo has nothing
+              to hand the OAuth code to. */}
+          {!demoMode && (
+            <>
+              <div className="flex items-center gap-3 my-4" aria-hidden>
+                <span className="flex-1 h-px bg-black/8" />
+                <span className="text-[11px] text-[#8E8E93] font-semibold">{t.authOrDivider}</span>
+                <span className="flex-1 h-px bg-black/8" />
+              </div>
+              <motion.button
+                type="button"
+                whileTap={{ scale: 0.97 }}
+                onClick={signInWithGoogle}
+                disabled={loading}
+                className="w-full flex items-center justify-center gap-2.5 py-2.5 rounded-2xl bg-white border border-[#E5E5EA] shadow-sm text-sf-subhead font-semibold text-[#1C1C1E] hover:bg-[#FAFAFA] transition disabled:opacity-50"
+              >
+                <svg width="17" height="17" viewBox="0 0 18 18" aria-hidden>
+                  <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.7-1.57 2.68-3.88 2.68-6.62z" />
+                  <path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.32-1.58-5.03-3.7H.96v2.33A9 9 0 0 0 9 18z" />
+                  <path fill="#FBBC05" d="M3.97 10.72a5.4 5.4 0 0 1 0-3.44V4.95H.96a9 9 0 0 0 0 8.1l3.01-2.33z" />
+                  <path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.35l2.58-2.58A9 9 0 0 0 .96 4.95l3.01 2.33C4.68 5.16 6.66 3.58 9 3.58z" />
+                </svg>
+                {t.authContinueWithGoogle}
+              </motion.button>
+            </>
+          )}
         </div>
 
         <p className="text-center text-sf-footnote text-[#8E8E93] mt-6">{t.authTagline}</p>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -13,6 +13,7 @@ import BuildFromTextModal from '../components/BuildFromTextModal'
 import BrandMark from '../components/BrandMark'
 import TutorialOverlay, { type TourStep } from '../components/TutorialOverlay'
 import JoinTreeModal from '../components/JoinTreeModal'
+import SecuritySettingsModal from '../components/security/SecuritySettingsModal'
 import TreeCardActionMenu from '../components/TreeCardActionMenu'
 import { shouldAutoShowTutorial, recordTutorialShown } from '../lib/tutorialState'
 import type { Member, Relationship } from '../types'
@@ -137,6 +138,8 @@ export default function Dashboard({ demoMode }: Props) {
   // Join-tree-by-code modal — reachable from both the QuickAccessMenu
   // and the new "🔑" tile in the Apps grid below.
   const [joinTreeOpen, setJoinTreeOpen] = useState(false)
+  // Account-security modal (opt-in two-factor) — real backend only.
+  const [securityOpen, setSecurityOpen] = useState(false)
   useEffect(() => {
     if (!shouldAutoShowTutorial(TUTORIAL_KEY)) return
     // small delay so the page paints first
@@ -354,6 +357,19 @@ export default function Dashboard({ demoMode }: Props) {
             </button>
             {!demoMode && (
               <button
+                onClick={() => setSecurityOpen(true)}
+                title={t.securityTitle}
+                aria-label={t.securityTitle}
+                className="w-8 h-8 bg-white/70 backdrop-blur border border-white/50 rounded-xl flex items-center justify-center hover:bg-white/90 transition"
+              >
+                <svg width="14" height="14" viewBox="0 0 15 15" fill="none">
+                  <path d="M7.5 1.5l5 2v3.6c0 3-2.1 5.6-5 6.4-2.9-.8-5-3.4-5-6.4V3.5l5-2z" stroke="#636366" strokeWidth="1.3" strokeLinejoin="round" />
+                  <path d="M5.3 7.5l1.5 1.5 2.9-3" stroke="#636366" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </button>
+            )}
+            {!demoMode && (
+              <button
                 onClick={async () => { await supabase.auth.signOut(); navigate('/') }}
                 title={t.signOut}
                 className="w-8 h-8 bg-white/70 backdrop-blur border border-white/50 rounded-xl flex items-center justify-center hover:bg-white/90 transition"
@@ -363,6 +379,7 @@ export default function Dashboard({ demoMode }: Props) {
                 </svg>
               </button>
             )}
+            <SecuritySettingsModal open={securityOpen} onClose={() => setSecurityOpen(false)} />
           </div>
         </div>
 


### PR DESCRIPTION
## Batch 3 — auth & polish
All verified in-browser (demo mode) where verifiable locally; OAuth/2FA live paths need the dashboard config session (below).

- **Google sign-in** — "Continue with Google" on the Auth page (`signInWithOAuth`, real backend only). Phone biometrics (fingerprint/face) come free via Google — the agreed approach instead of custom passkeys.
- **Opt-in TOTP 2FA** — `SecuritySettingsModal` (QR enroll → verify → disable) behind a new shield button on the Dashboard; `MfaChallengeGate` replaces the whole router while a session still needs its second factor, so AAL2 can't be bypassed by deep-linking.
- **z-layering fix** — open filter popover / focus picker now paint above the "?" help chip and the bottom nav (owner screenshot).
- **Coach-mark arrows** — side arrows now match language direction (SVG doesn't mirror in RTL).
- **DB scripts (run separately with owner approval)** — `seed-demo-tree.ts --rename-to` frees the demo tree's name; new `restore-real-family.ts` rebuilds the real ~73-member family from git history into a fresh tree.

## Gates
typecheck clean · 54/54 tests green · eslint 0 errors · production build OK

## Remaining manual steps (with owner)
1. Google Cloud OAuth client + Supabase Google provider (via owner's browser; secret pasted by owner).
2. Confirm TOTP enrollment is enabled in Supabase Auth settings.
3. Approve + run: migration 012, demo-tree rename+reseed, real-family restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)