### PR TITLE
feat(funnel): batch 5 - forgot password, edit suggestions, OAuth onboarding routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,9 +15,10 @@ import InstallPrompt from './components/InstallPrompt'
 import VersionUpdateModal from './components/VersionUpdateModal'
 import DevEnvBanner from './components/DevEnvBanner'
 import MfaChallengeGate from './components/security/MfaChallengeGate'
+import NewPasswordScreen from './components/security/NewPasswordScreen'
 import PlanGateToast from './components/plan/PlanGateToast'
 import { ADLER_MEMBERS, ADLER_RELATIONSHIPS, ADLER_TREES } from './data/adlerFamily'
-import { isPendingOnboarding, clearPendingOnboarding } from './lib/pendingOnboarding'
+import { isPendingOnboarding, clearPendingOnboarding, markPendingOnboarding } from './lib/pendingOnboarding'
 import type { Profile } from './types'
 import type { Session } from '@supabase/supabase-js'
 
@@ -335,6 +336,11 @@ export default function App() {
     // localStorage on every mutation, which would re-fire the effect.
   }, [demoMode, session?.user?.id])
 
+  // Password-recovery flow: the email link lands the user back here
+  // with a recovery session; instead of the app, they get the
+  // set-a-new-password screen until they choose one.
+  const [recoveryMode, setRecoveryMode] = useState(false)
+
   // Supabase auth
   useEffect(() => {
     if (!SUPABASE_CONFIGURED) return
@@ -342,7 +348,10 @@ export default function App() {
       setSession(session)
       setAuthLoading(false)
     })
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_e, s) => setSession(s))
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, s) => {
+      setSession(s)
+      if (event === 'PASSWORD_RECOVERY') setRecoveryMode(true)
+    })
     return () => subscription.unsubscribe()
   }, [])
 
@@ -374,6 +383,20 @@ export default function App() {
         full_name: session.user.user_metadata?.full_name ?? session.user.email ?? 'User',
         role: 'user',
       })
+      // Fresh signups get routed through the onboarding wizard. The
+      // email-signup path sets the pending flag in Auth.tsx, but OAuth
+      // (Google) can't — the page redirects away before we know whether
+      // this account is new. "Created in the last 10 minutes and not
+      // onboarded" is the provider-agnostic signal; old accounts with a
+      // legacy null onboarded_at are untouched.
+      const createdAtMs = new Date(session.user.created_at).getTime()
+      if (
+        Number.isFinite(createdAtMs) &&
+        Date.now() - createdAtMs < 10 * 60_000 &&
+        !(data as { onboarded_at?: string | null } | null)?.onboarded_at
+      ) {
+        markPendingOnboarding()
+      }
       fetchMembers(); fetchRelationships(); fetchEditRequests(); fetchTrees(); fetchMyPlan()
     }
     load()
@@ -455,6 +478,15 @@ export default function App() {
           transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
           className="w-8 h-8 border-2 border-[#007AFF]/20 border-t-[#007AFF] rounded-full"
         />
+      </div>
+    )
+  }
+
+  // Recovery-link wall: choose a new password before anything else.
+  if (SUPABASE_CONFIGURED && recoveryMode && session) {
+    return (
+      <div dir={dir}>
+        <NewPasswordScreen onDone={() => setRecoveryMode(false)} />
       </div>
     )
   }

--- a/src/components/EditMemberModal.tsx
+++ b/src/components/EditMemberModal.tsx
@@ -11,6 +11,12 @@ interface Props {
   open: boolean
   onClose: () => void
   member: Member
+  /**
+   * Regular-user path: the same form, but saving SUBMITS an edit
+   * request for admin approval instead of writing the member directly
+   * (the requester has no edit rights on this member).
+   */
+  suggestMode?: boolean
 }
 
 interface FormState {
@@ -62,8 +68,8 @@ function readFileAsDataUrl(file: File): Promise<string> {
   })
 }
 
-export default function EditMemberModal({ open, onClose, member }: Props) {
-  const { updateMember, members, relationships } = useFamilyStore()
+export default function EditMemberModal({ open, onClose, member, suggestMode = false }: Props) {
+  const { updateMember, submitEditRequest, members, relationships } = useFamilyStore()
   // Parents of this member — used by the "connector parent" picker so
   // the user can choose which parent the descending tree-line draws
   // from (default: mother).
@@ -129,7 +135,7 @@ export default function EditMemberModal({ open, onClose, member }: Props) {
   const handleSave = async () => {
     setSaving(true)
     const parsedOrder = form.birth_order.trim() === '' ? null : parseInt(form.birth_order, 10)
-    await updateMember(member.id, {
+    const changes = {
       first_name: form.first_name.trim() || member.first_name,
       last_name: form.last_name.trim(),
       maiden_name: form.maiden_name.trim() || undefined,
@@ -146,7 +152,17 @@ export default function EditMemberModal({ open, onClose, member }: Props) {
       photos: form.photos.length ? form.photos : undefined,
       hidden: form.hidden,
       connector_parent_id: form.connector_parent_id || null,
-    })
+    }
+    if (suggestMode) {
+      // No edit rights on this member — the change lands in the admin's
+      // requests tab instead of being written directly.
+      const sent = await submitEditRequest(member.id, changes)
+      setSaving(false)
+      if (sent) window.alert(t.editSuggestSent)
+      onClose()
+      return
+    }
+    await updateMember(member.id, changes)
     setSaving(false)
     onClose()
   }
@@ -189,7 +205,7 @@ export default function EditMemberModal({ open, onClose, member }: Props) {
                 disabled={saving}
                 className="px-3 py-1.5 text-sf-subhead font-bold text-[#007AFF] rounded-lg active:bg-[#007AFF]/10 disabled:opacity-60"
               >
-                {saving ? t.editSaving : t.save}
+                {saving ? t.editSaving : suggestMode ? t.editSuggestSubmit : t.save}
               </button>
             </div>
 
@@ -547,7 +563,7 @@ export default function EditMemberModal({ open, onClose, member }: Props) {
                 disabled={saving}
                 className="btn-primary w-full mt-2 disabled:opacity-60"
               >
-                {saving ? t.editSaving : t.editSaveChanges}
+                {saving ? t.editSaving : suggestMode ? t.editSuggestSubmit : t.editSaveChanges}
               </button>
             </div>
           </motion.div>

--- a/src/components/MemberPanel.tsx
+++ b/src/components/MemberPanel.tsx
@@ -617,6 +617,25 @@ export default function MemberPanel({ onClose }: Props) {
               <span>{t.panelEdit}</span>
             </button>
             )}
+            {/* Members outside the user's nuclear family: same form, but
+                saving submits an edit PROPOSAL for admin approval — this
+                is the producer side of the admin "requests" tab, which
+                previously had no way to receive anything. Guests stay
+                read-only. */}
+            {!editAllowed && profile?.role === 'user' && (
+            <button
+              type="button"
+              onClick={() => setEditOpen(true)}
+              aria-label={t.panelSuggestEdit}
+              title={t.panelSuggestEdit}
+              className="w-full py-3 rounded-2xl bg-[#007AFF]/10 text-[#007AFF] text-sf-subhead font-bold active:scale-[0.98] transition flex items-center justify-center gap-2"
+            >
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                <path d="M2.5 12V14H4.5L13 5.5L11 3.5L2.5 12Z" stroke="currentColor" strokeWidth="1.4" strokeLinejoin="round" />
+              </svg>
+              <span>{t.panelSuggestEdit}</span>
+            </button>
+            )}
             {relAllowed && (
             <button
               type="button"
@@ -699,7 +718,12 @@ export default function MemberPanel({ onClose }: Props) {
         )}
       </div>
 
-      <EditMemberModal open={editOpen} onClose={() => setEditOpen(false)} member={member} />
+      <EditMemberModal
+        open={editOpen}
+        onClose={() => setEditOpen(false)}
+        member={member}
+        suggestMode={!editAllowed}
+      />
       <RelationshipManager open={relOpen} onClose={() => setRelOpen(false)} member={member} />
 
       {/* Build-from-text → real local parser. The modal frames itself

--- a/src/components/security/NewPasswordScreen.tsx
+++ b/src/components/security/NewPasswordScreen.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react'
+import { motion } from 'framer-motion'
+import { supabase } from '../../lib/supabase'
+import { useLang, isRTL } from '../../i18n/useT'
+
+/**
+ * Set-a-new-password screen. Rendered by App.tsx instead of the router
+ * when the session arrived through a password-recovery link (the
+ * PASSWORD_RECOVERY auth event) — the user lands here straight from
+ * the email and chooses a fresh password.
+ */
+export default function NewPasswordScreen({ onDone }: { onDone: () => void }) {
+  const { t, lang } = useLang()
+  const rtl = isRTL(lang)
+  const [pass1, setPass1] = useState('')
+  const [pass2, setPass2] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [done, setDone] = useState(false)
+
+  const submit = async () => {
+    setError(null)
+    if (pass1.length < 8) {
+      setError(t.resetTooShort)
+      return
+    }
+    if (pass1 !== pass2) {
+      setError(t.resetMismatch)
+      return
+    }
+    setBusy(true)
+    try {
+      const { error } = await supabase.auth.updateUser({ password: pass1 })
+      if (error) throw error
+      setDone(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'error')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div dir={rtl ? 'rtl' : 'ltr'} className="min-h-screen bg-mesh-gradient flex items-center justify-center p-6">
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, ease: [0.16, 1, 0.3, 1] }}
+        className="w-full max-w-xs rounded-3xl bg-white shadow-glass-lg p-6 space-y-4 text-center"
+      >
+        {done ? (
+          <>
+            <span className="mx-auto w-12 h-12 rounded-2xl bg-[#34C759]/12 flex items-center justify-center">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
+                <path d="M5 12.5l4.5 4.5L19 7.5" stroke="#34C759" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </span>
+            <h1 className="text-sf-headline font-bold text-[#1C1C1E]">{t.resetDone}</h1>
+            <button
+              type="button"
+              onClick={onDone}
+              className="w-full py-2.5 rounded-2xl bg-gradient-to-r from-[#007AFF] to-[#32ADE6] text-white text-sf-subhead font-bold"
+            >
+              {t.resetContinue}
+            </button>
+          </>
+        ) : (
+          <>
+            <div>
+              <h1 className="text-sf-headline font-bold text-[#1C1C1E]">{t.resetTitle}</h1>
+              <p className="text-[12px] text-[#8E8E93] mt-1 leading-relaxed">{t.resetDesc}</p>
+            </div>
+            <input
+              autoFocus
+              type="password"
+              autoComplete="new-password"
+              value={pass1}
+              onChange={(e) => setPass1(e.target.value)}
+              placeholder={t.resetNewPassword}
+              className="input-field"
+            />
+            <input
+              type="password"
+              autoComplete="new-password"
+              value={pass2}
+              onChange={(e) => setPass2(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && submit()}
+              placeholder={t.resetConfirmPassword}
+              className="input-field"
+            />
+            {error && (
+              <p className="text-sf-footnote text-[#FF3B30] bg-[#FF3B30]/8 rounded-lg px-3 py-2">{error}</p>
+            )}
+            <button
+              type="button"
+              disabled={busy || !pass1 || !pass2}
+              onClick={submit}
+              className="w-full py-2.5 rounded-2xl bg-gradient-to-r from-[#007AFF] to-[#32ADE6] text-white text-sf-subhead font-bold disabled:opacity-40"
+            >
+              {busy ? '…' : t.resetSubmit}
+            </button>
+          </>
+        )}
+      </motion.div>
+    </div>
+  )
+}

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -803,6 +803,25 @@ export const translations = {
     aiNoLeaves: 'אין מספיק עלים לפעולה הזו ({n} נדרשים). אפשר לשדרג מסלול או לחכות לחידוש החודשי.',
     adminPlanLabel: 'מסלול',
     adminGrantLeaves: '+50 עלים',
+
+    // Forgot / reset password
+    authForgotPassword: 'שכחתי סיסמה',
+    authForgotNeedEmail: 'הזינו קודם את כתובת המייל בשדה למעלה, ואז לחצו שוב.',
+    authResetSent: 'נשלח אליכם מייל עם קישור לאיפוס הסיסמה. בדקו גם בספאם.',
+    resetTitle: 'קביעת סיסמה חדשה',
+    resetDesc: 'הגעתם מקישור האיפוס — בחרו סיסמה חדשה לחשבון.',
+    resetNewPassword: 'סיסמה חדשה (8 תווים לפחות)',
+    resetConfirmPassword: 'אימות הסיסמה החדשה',
+    resetTooShort: 'הסיסמה צריכה להיות באורך 8 תווים לפחות.',
+    resetMismatch: 'הסיסמאות לא זהות — נסו שוב.',
+    resetSubmit: 'שמירת הסיסמה',
+    resetDone: 'הסיסמה עודכנה!',
+    resetContinue: 'המשך לאפליקציה',
+
+    // Suggest-edit (regular users, outside nuclear family)
+    panelSuggestEdit: 'הצע עריכה',
+    editSuggestSubmit: 'שלח לאישור המנהל',
+    editSuggestSent: 'ההצעה נשלחה! המנהל יבדוק ויאשר אותה בקרוב.',
   },
 
   en: {
@@ -1595,6 +1614,25 @@ export const translations = {
     aiNoLeaves: 'Not enough leaves for this action ({n} needed). Upgrade your plan or wait for the monthly refill.',
     adminPlanLabel: 'Plan',
     adminGrantLeaves: '+50 leaves',
+
+    // Forgot / reset password
+    authForgotPassword: 'Forgot password',
+    authForgotNeedEmail: 'Enter your email in the field above first, then tap again.',
+    authResetSent: 'We emailed you a password-reset link. Check spam too.',
+    resetTitle: 'Set a new password',
+    resetDesc: 'You arrived from the reset link — choose a new password for your account.',
+    resetNewPassword: 'New password (8+ characters)',
+    resetConfirmPassword: 'Confirm new password',
+    resetTooShort: 'Password must be at least 8 characters.',
+    resetMismatch: 'Passwords do not match — try again.',
+    resetSubmit: 'Save password',
+    resetDone: 'Password updated!',
+    resetContinue: 'Continue to the app',
+
+    // Suggest-edit (regular users, outside nuclear family)
+    panelSuggestEdit: 'Suggest an edit',
+    editSuggestSubmit: 'Send for admin approval',
+    editSuggestSent: 'Suggestion sent! The admin will review it shortly.',
   },
 } as const
 

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -35,6 +35,28 @@ export default function Auth({ demoMode = false, onDemoEnter }: Props) {
 
   const dir = lang === 'he' ? 'rtl' : 'ltr'
 
+  // Password-reset email. Uses whatever is typed in the email field —
+  // no separate dialog needed. Supabase sends a recovery link; landing
+  // back here with it fires PASSWORD_RECOVERY, which App.tsx catches
+  // with the set-new-password screen.
+  const forgotPassword = async () => {
+    setError(null)
+    setSuccess(null)
+    if (!email.trim()) {
+      setError(t.authForgotNeedEmail)
+      return
+    }
+    try {
+      const { error } = await supabase.auth.resetPasswordForEmail(email.trim(), {
+        redirectTo: `${window.location.origin}/`,
+      })
+      if (error) throw error
+      setSuccess(t.authResetSent)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t.genericError)
+    }
+  }
+
   // OAuth redirect flow — Supabase hands off to Google and returns to
   // this origin with session tokens in the URL hash; supabase-js's
   // detectSessionInUrl consumes them and onAuthStateChange in App.tsx
@@ -266,6 +288,19 @@ export default function Auth({ demoMode = false, onDemoEnter }: Props) {
                 )}
               </button>
             </div>
+
+            {/* Forgot password — login mode + real backend only. */}
+            {mode === 'login' && !demoMode && (
+              <div className="text-start">
+                <button
+                  type="button"
+                  onClick={forgotPassword}
+                  className="text-[12px] font-semibold text-[#007AFF] hover:underline"
+                >
+                  {t.authForgotPassword}
+                </button>
+              </div>
+            )}
 
             <AnimatePresence>
               {error && (

--- a/src/store/useFamilyStore.ts
+++ b/src/store/useFamilyStore.ts
@@ -106,6 +106,11 @@ interface FamilyState {
 
   approveEditRequest: (requestId: string) => Promise<void>
   rejectEditRequest: (requestId: string) => Promise<void>
+  /** Regular-user path: propose a member edit for admin approval. */
+  submitEditRequest: (
+    targetMemberId: string,
+    changeData: Record<string, unknown>,
+  ) => Promise<boolean>
 
   // ── Onboarding + RBAC (Phase C/D) ───────────────────────────────────
   accessRequests: AccessRequest[]
@@ -623,6 +628,43 @@ export const useFamilyStore = create<FamilyState>((set, get) => ({
     // Refresh from the server so any constraints / triggers that
     // shape the result (computed columns, defaults) are reflected.
     await get().fetchMembers()
+  },
+
+  submitEditRequest: async (targetMemberId, changeData) => {
+    const me = get().profile
+    if (!me) return false
+    // Optimistic append so a demo admin (or the requester themselves,
+    // pre-refresh) sees the proposal immediately in the requests tab.
+    const member = get().members.find((m) => m.id === targetMemberId)
+    const localId = `er-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
+    const optimistic: EditRequest = {
+      id: localId,
+      requester_id: me.id,
+      requester_name: me.full_name,
+      target_member_id: targetMemberId,
+      target_member_name: member ? `${member.first_name} ${member.last_name}` : undefined,
+      change_data: changeData,
+      status: 'pending',
+      created_at: new Date().toISOString(),
+    }
+    set((s) => ({ editRequests: [optimistic, ...s.editRequests] }))
+    if (!isSupabaseConfigured) return true
+    try {
+      const { error } = await supabase.from('edit_requests').insert({
+        requester_id: me.id,
+        target_member_id: targetMemberId,
+        change_data: changeData,
+        status: 'pending',
+      })
+      if (error) {
+        reportSupabaseFailure('submitEditRequest', error)
+        return false
+      }
+      return true
+    } catch (err) {
+      reportSupabaseFailure('submitEditRequest', err)
+      return false
+    }
   },
 
   rejectEditRequest: async (requestId) => {


### PR DESCRIPTION
## Batch 5 — approved signup-flow recommendations

- **Forgot password** — link on the login form sends the Supabase recovery email; the recovery link lands on a full-screen "set a new password" wall (PASSWORD_RECOVERY event) before any route renders.
- **Edit suggestions** — the admin "requests" tab finally has a producer: a user-role account viewing a member outside their nuclear family gets a "suggest an edit" button; the same edit form submits an `edit_request` for admin approval (RLS `er_insert_auth` already existed). Verified end-to-end in demo.
- **OAuth onboarding** — Google signups now reach the onboarding wizard: any session whose auth user was created in the last 10 minutes without `onboarded_at` is flagged pending-onboarding (provider-agnostic; legacy null-onboarded accounts untouched).

## Gates
typecheck clean · 68/68 tests green · eslint 0 errors · build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)